### PR TITLE
fix: Incorrect REUSE syntax

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -7,5 +7,5 @@ SPDX-PackageComment = "The code in this project may include calls to APIs (\"API
 [[annotations]]
 path = "**"
 precedence = "aggregate"
-SPDX-FileCopyrightText = Copyright SAP SE or an SAP affiliated Company and Open Resource Discovery contributors.
+SPDX-FileCopyrightText = "Copyright SAP SE or an SAP affiliated Company and Open Resource Discovery contributors."
 SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
This PR fixes the syntax of the file `REUSE.toml`.
As it is, the repository is showing a non-compliant status on the REUSE badge:
<img width="712" height="200" alt="screenshot of the specification repository showing the non-compliant status on the REUSE badge" src="https://github.com/user-attachments/assets/8fd415e4-e3b3-432e-abe3-10302158ffc3" />
