### PR TITLE
Fix typos in ORD specification documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,13 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 ### Removed
 
 - deleted SAP specific values from ORD Configuration:
-  - `AccessStrategy` values: `sap:oauth-client-credentials:v1`, `sap:cmp-mtls:v1`, `sap.businesshub:basic-auth:v1` but any string with pattern `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using this values is still allowed
+  - `AccessStrategy` values: `sap:oauth-client-credentials:v1`, `sap:cmp-mtls:v1`, `sap.businesshub:basic-auth:v1` but any string with pattern `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
 
 - deleted SAP specific values from ORD Document:
-  - `policyLevel` values: `sap:base:v1`, `sap:core:v1`, `sap:dp:v1` but any string with pattern `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using this values is still allowed
-  - `ApiResource.implementationStandard` values: `sap:ord-document-api:v1`, `sap:csn-exposure:v1`, `sap:ape-api:v1`, `sap:cdi-api:v1`, `sap:delta-sharing:v1`, `sap:hana-cloud-sql:v1`, `sap.dp:data-subscription-api:v1` but any string with pattern `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using this values is still allowed
-  - `Package.policyLevel`, `ApiResource.policyLevel`, `EventResource.policyLevel`, `EntityType.policyLevel`, `DataProduct.policyLevel` values: `sap:base:v1`, `sap:core:v1`, `sap:dp:v1` but any string with pattern `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using this values is still allowed
-  - `AccessStrategy` values: `sap:oauth-client-credentials:v1`, `sap:cmp-mtls:v1`, `sap.businesshub:basic-auth:v1` but any string with pattern `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using this values is still allowed
+  - `policyLevel` values: `sap:base:v1`, `sap:core:v1`, `sap:dp:v1` but any string with pattern `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
+  - `ApiResource.implementationStandard` values: `sap:ord-document-api:v1`, `sap:csn-exposure:v1`, `sap:ape-api:v1`, `sap:cdi-api:v1`, `sap:delta-sharing:v1`, `sap:hana-cloud-sql:v1`, `sap.dp:data-subscription-api:v1` but any string with pattern `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
+  - `Package.policyLevel`, `ApiResource.policyLevel`, `EventResource.policyLevel`, `EntityType.policyLevel`, `DataProduct.policyLevel` values: `sap:base:v1`, `sap:core:v1`, `sap:dp:v1` but any string with pattern `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
+  - `AccessStrategy` values: `sap:oauth-client-credentials:v1`, `sap:cmp-mtls:v1`, `sap.businesshub:basic-auth:v1` but any string with pattern `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
 
 ## [1.12.3]
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The ORD standard is governed by the [Linux Foundation](https://www.linuxfoundati
 
 ### Learning Material
 
-Currently there are no public resources beside the ORD spec itself.
+Currently there are no public resources besides the ORD spec itself.
 We plan to add more in the future.
 
 ### Tools and Examples

--- a/docs/help/faq/index.md
+++ b/docs/help/faq/index.md
@@ -44,7 +44,7 @@ We're aware that some use-cases require faster metadata updates and the ORD spec
 
 ORD does not make a distinction between on-premises or cloud software.
 However On-premises software has implications on how (and whether at all) the ORD information can be accessed.
-Effectively, whether on-premises is supported or not depends on whether the connectivity between the the ORD aggregators (the system that are collecting the information) and the On-premises ORD providers can be established.
+Effectively, whether on-premises is supported or not depends on whether the connectivity between the ORD aggregators (the systems that are collecting the information) and the On-premises ORD providers can be established.
 In SAP context, we support including On-Premises software through [Cloud Connectors](https://help.sap.com/viewer/cca91383641e40ffbe03bdc78f00f681/Cloud/en-US/e6c7616abb5710148cfcf3e75d96d596.html?q=cloud%20connector).
 
 #### Q: What does "Open" in ORD stand for?

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -8,7 +8,7 @@ toc_max_heading_level: 3
 
 ## Why ORD?
 
-- Need for consistent **technical documentation how applications and services can be integrated with and developed against**.
+- Need for consistent **technical documentation of how applications and services can be integrated with and developed against**.
 - Companies and their customers need to **understand actual system landscapes, reflecting customizations and extensions**.
 - Need to provide **more automation and a better development experience** for integrating SAP products with each other, the BTP SAP ecosystem and side-by-side extensions.
 - Many AI and Analytics use-cases **rely on consistent and standardized metadata** to deliver value or scale well.
@@ -58,13 +58,13 @@ Typically, ORD is used to describe [APIs](./spec-v1/interfaces/Document.md#api-r
 With [Integration Dependencies](./spec-v1/interfaces/Document.md#integration-dependency) the (potential) use of external resources can be stated, too.
 In case that the standardized concepts or attributes are not sufficient, there are extensibility attributes and [Capabilities](./spec-v1/interfaces/Document.md#capability).
 
-ORD standardizes how those information can be automatically discovered and aggregated.
+ORD standardizes how this information can be automatically discovered and aggregated.
 Please note that ORD is no replacement for detailed resource definition standards like OpenAPI.
 Instead, it describes a bigger context with shared, high-level information, taxonomy and relations between the described resources.
 It also standardizes the publishing and discovery related interfaces and behaviors, to ensure a high degree of automation that allows us to keep in sync with reality.
 The same ORD implementation can be used to both describe the tenant-specific customer landscape and the static reference landscape view to an API Catalog.
 
-When ORD information get combined by a central ORD aggregator and integrated with other, central metadata sources, we can realize a connected (customer) **system landscape metadata view**.
+When ORD information gets combined by a central ORD aggregator and integrated with other, central metadata sources, we can realize a connected (customer) **system landscape metadata view**.
 This gives both SAP and our customers better introspection about the actual system landscape. This enables or improves many meta-data driven use-cases (like low-code/no-code).
 
 The specification provides a shared contract and alignment point for the ecosystem, spanning various consumers and providers. This allows to have one aligned standard instead of a wild growth of specific point-to-point alignments and integrations.
@@ -77,7 +77,7 @@ The specification provides a shared contract and alignment point for the ecosyst
 
 The most typical resources to describe are [APIs](./spec-v1/interfaces/Document.md#api-resource) and [Events](./spec-v1/interfaces/Document.md#event-resource).
 But ORD can also be used to describe higher-level concepts like [Entity Types](./spec-v1/interfaces/Document.md#entity-type) (Business Objects) and [Data Products](./spec-v1/interfaces/Document.md#data-products).
-With [Integration Dependencies](./spec-v1/interfaces/Document.md#integration-dependency) it is possible to also describe how external resources are or can be be used.
+With [Integration Dependencies](./spec-v1/interfaces/Document.md#integration-dependency) it is possible to also describe how external resources are or can be used.
 In case that the standardized concepts or attributes are not sufficient, there are extensibility attributes and [Capabilities](./spec-v1/interfaces/Document.md#capability).
 
 The mentioned concepts can be grouped by different concerns via [Packages](./spec-v1/interfaces/Document.md#package) and [Consumption Bundles](./spec-v1/interfaces/Document.md#consumption-bundle) and various taxonomy attributes.
@@ -166,8 +166,8 @@ If ORD information are provided, the detail view can show them and they will be 
 We believe that standards and policies can only realistically be ensured if we can automatically verify for correctness and compliance.
 
 This is why we have a complementary project, called the API Metadata Validator [TODO: link].
-It can validate ORD documents, but also a other metadata formats that we usually pass along via the ORD protocol, like OpenAPI documents.
-We use this also to not just test for technical correctness, but also to ad here to certain compliance levels.
+It can validate ORD documents, but also other metadata formats that we usually pass along via the ORD protocol, like OpenAPI documents.
+We use this also to not just test for technical correctness, but also to adhere to certain compliance levels.
 
 ## ORD in More Detail
 

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -63,7 +63,7 @@ Based on this, many end-user use cases can be realized, e.g.:
 
 - Systems to **describe themselves** with a single entry-point to crawl all relevant metadata
 - Achieve a combined, machine-readable **system landscape metadata view**
-- Enable **fully automatic** of publication and discovery of metadata
+- Enable **fully automatic** publication and discovery of metadata
 - Having **one aligned standard** for
   - Description of different types of resources
   - Description of both the static / generic perspective and the actual runtime perspective
@@ -79,7 +79,7 @@ Based on this, many end-user use cases can be realized, e.g.:
 
 - Replace industry-standard resource definition formats like OpenAPI
 - Describing resources or capabilities in extensive detail.
-- Currently it is not recommended to put fast changing information into ORD, as the current pull-based transport mechanism would be to slow and expensive to support time-critical updates.
+- Currently it is not recommended to put fast changing information into ORD, as the current pull-based transport mechanism would be too slow and expensive to support time-critical updates.
   - This could change in the future by introducing more efficient, asynchronous transport modes.
 - Currently: Describe resources other than those that are owned and exposed by the systems directly
   (only self-description of systems).

--- a/docs/spec-extensions/policy-levels/sap-core-v1.md
+++ b/docs/spec-extensions/policy-levels/sap-core-v1.md
@@ -16,7 +16,7 @@ Exceptions are only allowed on a case by case basis.
 This policy level is based on various SAP guidelines and rules - most of them which are already established.
 It defines the core rules and guidelines that are shared across SAP, although more specific rules and guidelines MAY be applied on top.
 
-**All constraints of the ORD specification itself still apply (valid ORD document). The constrains described here come on top.**
+**All constraints of the ORD specification itself still apply (valid ORD document). The constraints described here come on top.**
 
 ## General Policies
 

--- a/docs/spec-v1/index.md
+++ b/docs/spec-v1/index.md
@@ -44,21 +44,14 @@ This specification defines and uses the following terms (for the ORD context):
 
 - A <dfn id="def-system">system</dfn> is sometimes used as a generic, imprecise term when no further distinctions are necessary.
   In most places, the specification uses more precise terms, though:
-  - A <dfn id="def-system-type">system type</dfn> is the abstract type of an application or service from operational perspective. It is also known as system role ([SAP CLD](https://support.sap.com/en/tools/software-logistics-tools/landscape-management-process/system-landscape-directory.html)). Within the specification it is sometimes referred to as _application and service_ for better readability.
-    Since system type is an abstract concept, it is not concretely addressable.
-    A [system installation](#def-system-installation) of a specific [system version](#def-system-version) and potentially a [system instance](#def-system-instance) needs to be created to have a concrete, addressable system.
 
-  - A <dfn id="def-system-type">system type</dfn> is the abstract type of an application or service. It is also known as SAP system role ([SAP CLD](https://support.sap.com/en/tools/software-logistics-tools/landscape-management-process/system-landscape-directory.html)). Within the specification it is also referred to as _application and service_ for better readability.
+  - A <dfn id="def-system-type">system type</dfn> is the abstract type of an application or service. It is also known as system role ([SAP CLD](https://support.sap.com/en/tools/software-logistics-tools/landscape-management-process/system-landscape-directory.html)). Within the specification it is also referred to as _application and service_ for better readability.
     Since system type is an abstract concept, it is not concretely addressable.
 
     Please note that a system type is similar, but not necessarily identical to a [product](#def-product).
     System type is a technical concept, while product is a term for external communication and sales.
 
   - A <dfn id="def-system-installation">system installation</dfn> is a concrete running instance of a <a href="#def-system-type">system type</a> of a specific [system version](#def-system-version). If the system type supports tenant isolation, a system installation may offer multiple <a href="#def-system-instance">system instance</a>. A system installation has at least one [base URL](#def-base-url).
-
-- A <dfn id="def-system-instance">system instance</dfn> is running instance of a <a href="#def-system-type">system type</a> and always refers to the _most specific_ instance from a customer / account perspective. Usually this is the boundary where the isolation of resources, capabilities and data is ensured.
-  If the system type offers tenant isolation (multi-tenancy), system instance refers to a tenant. If there is no tenant isolation, there are two options: Either the isolation is achieved by having a dedicated [system deployment](#def-system-deployment) per tenant or system isolation does not matter. In those cases system instance equals the system deployment.
-  - A <dfn id="def-system-version">system version</dfn> is a particular software version of an <a href="#def-system-installation">system installation</a>, which is always of the same <a href="#def-system-type">system type</a>.
 
   - A <dfn id="def-system-instance">system instance</dfn> is running, isolated instance of a <a href="#def-system-type">system type</a>, running in a <a href="#def-system-installation">system installation</a> of a particular <a href="#def-system-version">system version</a>. It always refers to the _most specific_ instance from a customer / account / data isolation perspective.
     If the system type offers tenant isolation (multi-tenancy), system instance refers to a tenant. If there is no tenant isolation, there are two options: Either the isolation is achieved by having a dedicated [system installation](#def-system-installation) per tenant or system isolation does not matter. In those cases system instance equals the system installation.
@@ -187,7 +180,7 @@ This is implemented by providing an [ORD Provider API](#ord-provider-api).
 ### Other Modes of Transport
 
 Other modes of transport have not yet been standardized/specified.
-They are are only listed here to outline potential modes that we anticipate.
+They are only listed here to outline potential modes that we anticipate.
 
 #### Import Transport
 
@@ -291,7 +284,7 @@ In some cases (like `policyLevel`), it is also possible to override the values l
 
 ##### Package Level Inheritance
 
-Some ORD information are described on Package level and inherited down to all resources it that are assigned to the it.
+Some ORD information are described on Package level and inherited down to all resources that are assigned to it.
 The information on package level are merged into resource level, but can be overridden locally at resource level.
 
 > Please note that package level inheritance might not always have the right granularity, as putting resources into packages can have a different motivation / cut than the reuse.
@@ -402,7 +395,7 @@ Content-Type: application/json
 
 The resulting ORD config MUST only return the ORD document(s) that contain the results from the select query (to avoid unnecessary requests). The aggregator will then request each listed document with the same `?select` parameter:
 
-If the given ORD ID is invalid he ORD provider MUST return 500, if it cannot be found, the ORD provider MUST return 404, see [error handling](#error-handling).
+If the given ORD ID is invalid the ORD provider MUST return 500, if it cannot be found, the ORD provider MUST return 404, see [error handling](#error-handling).
 
 ```http
 GET http://example.com/ord/document-1?select=sap.foo:dataProduct:astronomy:v1

--- a/docs/spec-v1/interfaces/Document.md
+++ b/docs/spec-v1/interfaces/Document.md
@@ -1072,7 +1072,7 @@ or through a defined and known `implementationStandard` that can resolve the `lo
 At SAP, the metadata about entity types could be retrieved via the CSN_EXPOSURE service.
 To indicate this, the service needs to be implemented and described in ORD with `implementationStandard` set to `sap:csn-exposure:v1`).
 
-ODM 2.0 relies on the entity type mappings and uses the the mapping to express the relationship of an API to the
+ODM 2.0 relies on the entity type mappings and uses the mapping to express the relationship of an API to the
 corresponding ODM entity. ORD consumers like SAP Business Accelerator Hub consume the mapping to make the relationships navigate-able for customers.
 
 **Type**: Object(<a href="#entity-type-mapping_apimodelselectors">apiModelSelectors</a>, <a href="#entity-type-mapping_entitytypetargets">entityTypeTargets</a>)


### PR DESCRIPTION
Fixed typos and spelling errors:
- CHANGELOG.md: "this values" → "these values" (5 instances)
- README.md: "beside" → "besides"
- docs/introduction.mdx: "a other" → "other"
- docs/introduction.mdx: "ad here" → "adhere"
- docs/spec-extensions/policy-levels/sap-core-v1.md: "constrains" → "constraints"

Fixed grammar and clarity issues:
- docs/introduction.mdx: Added "of" in "technical documentation of how applications"
- docs/introduction.mdx: "those information" → "this information"
- docs/introduction.mdx: "information get" → "information gets"
- docs/overview/index.md: Removed "of" from "fully automatic publication"
- docs/overview/index.md: "to slow" → "too slow"
- docs/help/faq/index.md: "system that are" → "systems that are"
- docs/spec-v1/index.md: "it that are assigned to the it" → "that are assigned to it"
- docs/spec-v1/index.md: "he ORD provider" → "the ORD provider"

Fixed duplicate words:
- docs/introduction.mdx: "can be be used" → "can be used"
- docs/spec-v1/index.md: "are are only" → "are only"
- docs/spec-v1/interfaces/Document.md: "the the mapping" → "the mapping"
- docs/help/faq/index.md: "the the ORD" → "the ORD"

Fixed duplicate definitions:
- docs/spec-v1/index.md: Removed duplicate "system type" definition
- docs/spec-v1/index.md: Removed duplicate "system instance" definition