### PR TITLE
Fix PR preview deployment to specification-preview repo

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -3,6 +3,11 @@ name: PR Preview
 on:
   pull_request:
     types: [opened, reopened, synchronize, closed]
+    paths:
+      - 'docs/**'
+      - 'static/**'
+      - 'src/theme/**'
+      - '.github/workflows/pr-preview.yml'
 
 permissions:
   contents: write

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -3,11 +3,13 @@ name: PR Preview (deploy to separate repo)
 on:
   pull_request:
     types: [opened, reopened, synchronize, closed]
-#    paths:
-#      - 'docs/**'
-#      - 'static/**'
-#      - 'src/theme/**'
-#      - '.github/workflows/pr-preview.yml'
+    paths:
+      - 'docs/**'
+      - 'static/**'
+      - 'src/theme/**'
+      - 'docusaurus.config.js'
+      - 'sidebars.js'
+      - '.github/workflows/pr-preview.yml'
 
 permissions:
   contents: write

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,13 +1,13 @@
-name: PR Preview
+name: PR Preview (deploy to separate repo)
 
 on:
   pull_request:
     types: [opened, reopened, synchronize, closed]
-    paths:
-      - 'docs/**'
-      - 'static/**'
-      - 'src/theme/**'
-      - '.github/workflows/pr-preview.yml'
+#    paths:
+#      - 'docs/**'
+#      - 'static/**'
+#      - 'src/theme/**'
+#      - '.github/workflows/pr-preview.yml'
 
 permissions:
   contents: write
@@ -24,7 +24,7 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - name: Checkout
+      - name: Checkout source repo
         uses: actions/checkout@v4
 
       - name: Setup Node
@@ -48,10 +48,12 @@ jobs:
           npm ci
           npm run build
 
-      - name: Deploy / Cleanup PR preview
+      - name: Deploy / Remove preview in spec-preview repo
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: build
+          deploy-repository: open-resource-discovery/specification-preview
           preview-branch: gh-pages
-          umbrella-dir: pr-previews
+          umbrella-dir: ./
           pages-base-url: open-resource-discovery.github.io/specification
+          token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -3,13 +3,6 @@ name: PR Preview (deploy to separate repo)
 on:
   pull_request:
     types: [opened, reopened, synchronize, closed]
-    paths:
-      - 'docs/**'
-      - 'static/**'
-      - 'src/theme/**'
-      - 'docusaurus.config.js'
-      - 'sidebars.js'
-      - '.github/workflows/pr-preview.yml'
 
 permissions:
   contents: write

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -36,13 +36,13 @@ jobs:
         if: github.event.action != 'closed'
         run: |
           set -euo pipefail
-          PR_PATH="/specification/pr-previews/pr-${{ github.event.pull_request.number }}/"
+          PR_PATH="/specification-preview/pr-${{ github.event.pull_request.number }}/"
           CFG="docusaurus.config.js"
 
           cp "$CFG" "$CFG.bak"
           trap 'mv -f "$CFG.bak" "$CFG"' EXIT
 
-          sed -i 's#const baseUrl = "/specification";#const baseUrl = "'"$PR_PATH"'" ;#' "$CFG"
+          sed -i "s#const baseUrl = \"/specification\";#const baseUrl = \"$PR_PATH\";#g" "$CFG"
           grep -q "$PR_PATH" "$CFG"
 
           npm ci
@@ -55,5 +55,5 @@ jobs:
           deploy-repository: open-resource-discovery/specification-preview
           preview-branch: gh-pages
           umbrella-dir: ./
-          pages-base-url: open-resource-discovery.github.io/specification
+          pages-base-url: open-resource-discovery.github.io/specification-preview
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -10,8 +10,6 @@ permissions:
 
 jobs:
   preview:
-    # no Forks (Security)
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     concurrency:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Build with PR-specific baseUrl
         if: github.event.action != 'closed'

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,52 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  preview:
+    # no Forks (Security)
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: preview-${{ github.repository }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build with PR-specific baseUrl
+        if: github.event.action != 'closed'
+        run: |
+          set -euo pipefail
+          PR_PATH="/specification/pr-previews/pr-${{ github.event.pull_request.number }}/"
+          CFG="docusaurus.config.js"
+
+          cp "$CFG" "$CFG.bak"
+          trap 'mv -f "$CFG.bak" "$CFG"' EXIT
+
+          sed -i 's#const baseUrl = "/specification";#const baseUrl = "'"$PR_PATH"'" ;#' "$CFG"
+          grep -q "$PR_PATH" "$CFG"
+
+          npm ci
+          npm run build
+
+      - name: Deploy / Cleanup PR preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: build
+          preview-branch: gh-pages
+          umbrella-dir: pr-previews
+          pages-base-url: open-resource-discovery.github.io/specification


### PR DESCRIPTION
This PR updates the preview workflow so Docusaurus builds use the correct baseUrl and deploy into the dedicated `specification-preview` repository. This enables clean, isolated PR previews under the correct path and domain.