### PR TITLE
Fix PR Preview: Ensure PAT is used instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   preview:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     concurrency:
@@ -17,6 +18,12 @@ jobs:
       cancel-in-progress: true
 
     steps:
+      - name: Debug – Job is running
+        run: |
+          echo "DEBUG: Running PR preview job"
+          echo "DEBUG: head.repo.full_name = ${{ github.event.pull_request.head.repo.full_name }}"
+          echo "DEBUG: repository        = ${{ github.repository }}"
+          echo "DEBUG: secret available  = ${{ secrets.PR_PREVIEW_TOKEN != '' }}"
       - name: Checkout source repo
         uses: actions/checkout@v6
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -18,12 +18,6 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - name: Debug – Job is running
-        run: |
-          echo "DEBUG: Running PR preview job"
-          echo "DEBUG: head.repo.full_name = ${{ github.event.pull_request.head.repo.full_name }}"
-          echo "DEBUG: repository        = ${{ github.repository }}"
-          echo "DEBUG: secret available  = ${{ secrets.PR_PREVIEW_TOKEN != '' }}"
       - name: Checkout source repo
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -18,10 +18,21 @@ jobs:
       cancel-in-progress: true
 
     steps:
+      - name: Debug – Job is running
+        run: |
+          echo "DEBUG: Running PR preview job"
+          echo "DEBUG: head.repo.full_name = ${{ github.event.pull_request.head.repo.full_name }}"
+          echo "DEBUG: repository        = ${{ github.repository }}"
+          echo "DEBUG: secret available  = ${{ secrets.PR_PREVIEW_TOKEN != '' }}"
+
       - name: Checkout source repo
         uses: actions/checkout@v6
-        with:
-          persist-credentials: false
+
+      - name: Print .git/config
+        run: |
+          echo "=== DEBUG: .git/config ==="
+          cat .git/config
+          echo "=========================="
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -26,6 +26,8 @@ jobs:
           echo "DEBUG: secret available  = ${{ secrets.PR_PREVIEW_TOKEN != '' }}"
       - name: Checkout source repo
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -18,27 +18,10 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - name: Debug – Job is running
-        run: |
-          echo "DEBUG: Running PR preview job"
-          echo "DEBUG: head.repo.full_name = ${{ github.event.pull_request.head.repo.full_name }}"
-          echo "DEBUG: repository        = ${{ github.repository }}"
-          echo "DEBUG: secret available  = ${{ secrets.PR_PREVIEW_TOKEN != '' }}"
-
       - name: Checkout source repo
         uses: actions/checkout@v6
-
-      - name: Print .git/config
-        run: |
-          echo "=== DEBUG: .git/config ==="
-          cat .git/config
-          echo "=========================="
-
-      - name: Print global git config
-        run: |
-          echo "=== DEBUG: git config --global --list ==="
-          git config --global --list || true
-          echo "========================================="
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -34,6 +34,12 @@ jobs:
           cat .git/config
           echo "=========================="
 
+      - name: Print global git config
+        run: |
+          echo "=== DEBUG: git config --global --list ==="
+          git config --global --list || true
+          echo "========================================="
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -3,7 +3,7 @@ $id: https://open-resource-discovery.github.io/specification/spec-v1/interfaces/
 title: Ord Document
 description: |-
   The [ORD Document](../index.md#ord-document) object serves as a wrapper for the **ORD resources** and **ORD taxonomy** and adds further top-level information
-  that are specific to the document/the service it describes. Test
+  that are specific to the document/the service it describes.
 
   The constraints and considerations on [ORD Documents](../index.md#ord-document) MUST be followed.
 

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -3,7 +3,7 @@ $id: https://open-resource-discovery.github.io/specification/spec-v1/interfaces/
 title: Ord Document
 description: |-
   The [ORD Document](../index.md#ord-document) object serves as a wrapper for the **ORD resources** and **ORD taxonomy** and adds further top-level information
-  that are specific to the document/the service it describes.
+  that are specific to the document/the service it describes.test
 
   The constraints and considerations on [ORD Documents](../index.md#ord-document) MUST be followed.
 

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -3,7 +3,7 @@ $id: https://open-resource-discovery.github.io/specification/spec-v1/interfaces/
 title: Ord Document
 description: |-
   The [ORD Document](../index.md#ord-document) object serves as a wrapper for the **ORD resources** and **ORD taxonomy** and adds further top-level information
-  that are specific to the document/the service it describes.test
+  that are specific to the document/the service it describes.
 
   The constraints and considerations on [ORD Documents](../index.md#ord-document) MUST be followed.
 

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -3,7 +3,7 @@ $id: https://open-resource-discovery.github.io/specification/spec-v1/interfaces/
 title: Ord Document
 description: |-
   The [ORD Document](../index.md#ord-document) object serves as a wrapper for the **ORD resources** and **ORD taxonomy** and adds further top-level information
-  that are specific to the document/the service it describes.
+  that are specific to the document/the service it describes. Test
 
   The constraints and considerations on [ORD Documents](../index.md#ord-document) MUST be followed.
 


### PR DESCRIPTION
Disable checkout credentials (`persist-credentials: false`) so the deployment action can push using the configured PAT instead of falling back to `github-actions[bot]`.