### PR TITLE
Add members to Group and add Group Type restriction hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+### Added
+
+- Added `members` assignment from a Group to ORD Resources
+  - So far, ORD resources could only define their `partOfGroups` assignment, assuming they know which group (instances) they belong to
+  - Sometimes not just the group taxonomy is defined externally, but also the group assignment. In this case, it is the group which knows which ORD resources are part of it (`members`), not vice versa
+  - For an ORD aggregator this comes with a new challenge, as the relationship between group and its constituents can be defined from both sides
+- Added `restrictDirection` to optionally restrict the direction of group assignments to either resource -> group or vice versa.
+- Added `restrictResourceType` to optionally restrict group assignments to one or more ORD resource types.
+
 ### Fixed
 
 - make AccessStrategy from ORD Configuration consistent with AccessStrategy from ORD Document (both should use `anyOf` for the allowed values)

--- a/docs/spec-v1/concepts/grouping-and-bundling.md
+++ b/docs/spec-v1/concepts/grouping-and-bundling.md
@@ -155,7 +155,7 @@ Example: Group Type: "Process", Group: ["Hire to Retire", "Travel to Reimburse"]
 
 Third, we need to assign the ORD resources to the groups, via:
 
-- `partOfGroup` assignment from ORD Resource to 0..n Groups
+- `partOfGroups` assignment from ORD Resource to 0..n Groups
 - `members` assignment from Group to 0..n ORD Resources
 
 E.g. a particular OData API for Employee Management can be part of both the "Employee Service" group (of Group Type "CSN Service") and the "Hire to Retire" group of Group Type "Process".

--- a/docs/spec-v1/concepts/grouping-and-bundling.md
+++ b/docs/spec-v1/concepts/grouping-and-bundling.md
@@ -163,7 +163,7 @@ E.g. a particular OData API for Employee Management can be part of both the "Emp
 Group Types and Groups can be locally defined by the ORD Provider ([system namespace](../../spec-v1/index.md#system-namespace)) or be defined globally ([authority namespace](../../spec-v1/index.md#authority-namespace)) if they are shared across different applications.
 
 Groups and even group types can be defined globally. If the Group Type is shared across different applications, it should have an [authority namespace](../index.md#authority-namespace).
-In this case it works like a global taxonomy with a predefined list of values.It's also possible for the application itself to define and assign its own Group Types (and instances).
+In this case it works like a global taxonomy with a predefined list of values. It's also possible for the application itself to define and assign its own Group Types (and instances).
 
 > The Group concept is correct choice when ORD resources need to be grouped through an explicit taxonomy, beyond the predefined taxonomy concepts from ORD (like Package). The advantage of groups over tags and labels is that their types and instance values can be defined, governed and listed.
 

--- a/docs/spec-v1/concepts/grouping-and-bundling.md
+++ b/docs/spec-v1/concepts/grouping-and-bundling.md
@@ -147,7 +147,7 @@ They are optimized towards machine-readability and can be used to query, select 
 </div>
 
 The concept has three parts: The **Group Type** defines the semantics / meaning of a particular type of group assignments.
-An example would be to have a Group Type for a "part of an CSN Service" or "part of a Process".
+An example would be to have a Group Type for a "CSN Service" or "Process".
 
 Second, the **Group** itself defines the actual group instances that resources can be assigned to.
 

--- a/docs/spec-v1/concepts/grouping-and-bundling.md
+++ b/docs/spec-v1/concepts/grouping-and-bundling.md
@@ -34,9 +34,13 @@ Some of them have a specific indented usage, while others offer the application 
 
 ### Namespaces
 
-While ORD IDs contain [namespaces](../index.md#namespaces) that can include optional [sub-context namespaces](../index.md#sub-context-namespace), these should NOT be used for grouping purposes. Changing sub-context namespaces creates incompatible changes by altering ORD IDs. Use [groups](#groups) for grouping instead.
+The ORD IDs contain a [namespace](../index.md#namespaces), which MAY include optional [sub-context namespaces](../index.md#sub-context-namespace).
+They act like a [DDD Bounded Context](https://martinfowler.com/bliki/BoundedContext.html) and allow the same `<resourceName>` to appear in multiple sub-namespaces.
 
-Sub-context namespaces should only be used if they are expected to be stable and are necessary to ensure conflict-free ORD IDs. A valid use case is enabling sub-teams to work independently with isolated, conflict-free sub-namespaces.
+Please be aware that changing the sub-context namespace is an incompatible change, as the ORD IDs change.
+Therefore it's NOT RECOMMENDED to use sub-context namespaces just for the purpose of grouping (use [groups](#groups) instead).
+They should only be used if they are expected to be stable and are necessary to ensure the overall ORD ID is conflict free.
+A good reason is to ensure that sub-teams can work independently on content and have an isolated, conflict free sub-namespace.
 
 ### ORD Documents
 
@@ -46,7 +50,7 @@ However, there are still some [Considerations on the granularity of ORD Document
 ## Best Practices and Recommendations
 
 - Avoid using [namespaces](#namespaces) for the purpose of grouping, if possible.
-- For end-user-facing taxonomy, use [groups](#groups) rather than tags or labels. Tags and labels lack human-readable labels and are optimized for machine processing.
+- To express end-user facing taxonomy, use [groups](#groups) and not tags or labels as they have no human-readable labels and are meant more for machine
 - Packages are less flexible for grouping than [groups](#groups), so the latter are recommended and can be complementary.
   Use [packages](#package) to group ORD resources published together and making use of the information reuse.
 
@@ -54,7 +58,7 @@ However, there are still some [Considerations on the granularity of ORD Document
 
 ### Package
 
-Every ORD Resource MUST be assigned to exactly one [**Package**](../interfaces/Document#package).
+Every ORD Resource MUST be assigned to exactly one [**Package**](../interfaces/document#package).
 The Package is primarily motivated by publishing and API catalog presentation concerns, including human-readable documentation and presentation.
 It can also express information about the resource providers, terms of use of the APIs, pricing for the usage of the packages, APIs, Events, etc.
 
@@ -79,10 +83,8 @@ This is the case, when:
 
 ### Consumption Bundle
 
-The [**Consumption Bundle**](../interfaces/Document#consumption-bundle) groups APIs and Events together that can be consumed with the same credentials and auth mechanism.
-Ideally it also includes instructions and details on how to request access and credentials for resources.
-
-> **Important:** A Consumption Bundle is a template that describes _how_ to obtain access, not _which_ credentials are already available. It provides instructions, not instances.
+The [**Consumption Bundle**](../interfaces/document#consumption-bundle) groups APIs and Events together that can be consumed with the credentials and auth mechanism.
+Ideally it also includes instructions and details how to request access and credentials for resources.
 
 API and Event resources MAY be assigned to 0..n Consumption Bundles.
 Consumption Bundles are only applicable to APIs and Events where the described application itself manages the access and credentials.
@@ -92,13 +94,15 @@ In practice however, there are usually more fine-grained access control permissi
 Those are currently not described in ORD and the Consumption Bundle should therefore describe the "maximum possible scope" that is theoretically possible.
 
 Within consumption bundle, we anticipate to provide more machine-readable information that help to understand and automate the necessary steps to get access.
-For example, how credentials can be programmatically obtained could be described by attached `credentialExchangeStrategies`.
+E.g. how credentials can be programmatically obtained could be described by attached `credentialExchangeStrategies`.
+
+> It is important to understand that the Consumption Bundle is conceptually like a Template or HowTo guide. It only provides information how access / credentials / clients can be obtained for API usage, not what is already available. The latter would be the result of an "instantiation" of a Consumption Bundle, or something that is already setup and managed by the application itself.
 
 > 🚧 Please note that the Consumption Bundle concept is still in a rather basic form and may be extended in the future.
 
 ### Entity Type
 
-An [**Entity Type**](../interfaces/Document#entity-type) describes a underlying conceptual model (e.g. a business object / domain model).
+An [**Entity Type**](../interfaces/document#entity-type) describes a underlying conceptual model (e.g. a business object / domain model).
 In special cases, the entity type could just be a term, describing the semantics but without an actual model behind it.
 
 They represent an "internal" concept and are part of the ORD taxonomy. They should not leak internal implementation details, but can be used to create relations to and between external resources and capabilities and relate them to "business semantics".
@@ -131,12 +135,12 @@ Since they are usually used for enhancing search or navigation, the simplicity o
 
 ### Labels
 
-[**Labels**](../interfaces/Document#labels) are very similar to [tags](#tags), but allow to define key value pairs.
+[**Labels**](../interfaces/document#labels) are very similar to [tags](#tags), but allow to define key value pairs.
 They are optimized towards machine-readability and can be used to query, select and filter resources (similar to [kubernetes labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)).
 
 ### Groups
 
-[**Groups**](../interfaces/Document#group) and the corresponding [Group Types](../interfaces/Document#group-type) can be used to define and apply your own taxonomy in a generic, extensible way.
+[**Groups**](../interfaces/document#group) and the corresponding [Group Types](../interfaces/document#group-type) can be used to define and apply your own taxonomy in a generic, extensible way.
 
 <div style={{"text-align": "left", "margin-top": "12px"}}>
 ![Group Concept Overview](/img/group-concept-overview.drawio.svg)
@@ -145,16 +149,23 @@ They are optimized towards machine-readability and can be used to query, select 
 The concept has three parts: The **Group Type** defines the semantics / meaning of a particular type of group assignments.
 An example would be to have a Group Type for a "part of an CSN Service" or "part of a Process".
 
-Second, the **Group** itself defines the actual group things can be assigned to.
-In the examples before, this would be the "Employee Service" or the "Hire to Retire" Process.
+Second, the **Group** itself defines the actual group instances that resources can be assigned to.
 
-Lastly, we need to state the **partOfGroup** assignment of a particular ORD Resource.
-E.g. a particular OData API for Employee Management can be part of both the "Employee Service" group (of type CSN Service) and the "Hire to Retire" group of type "Process".
+Example: Group Type: "Process", Group: ["Hire to Retire", "Travel to Reimburse"]
 
-The Group Type could even be defined globally. If the Group Type is shared across different applications, it should have an [authority namespace](../index.md#authority-namespace).
-The Group Instances can potentially be globally defined, too. In this case it works like a global taxonomy with a predefined list of values.It's also possible for the application itself to define and assign its own Group Types and Instances.
+Third, we need to assign the ORD resources to the groups, via:
 
-> The Group concept is correct choice when ORD resources need to be grouped by additional concerns, beyond the predefined concepts from ORD (like Package).
+- `partOfGroup` assignment from ORD Resource to 0..n Groups
+- `members` assignment from Group to 0..n ORD Resources
+
+E.g. a particular OData API for Employee Management can be part of both the "Employee Service" group (of Group Type "CSN Service") and the "Hire to Retire" group of Group Type "Process".
+
+Group Types and Groups can be locally defined by the ORD Provider ([system namespace](../../spec-v1/index.md#system-namespace)) or be defined globally ([authority namespace](../../spec-v1/index.md#authority-namespace)) if they are shared across different applications.
+
+Groups and even group types can be defined globally. If the Group Type is shared across different applications, it should have an [authority namespace](../index.md#authority-namespace).
+In this case it works like a global taxonomy with a predefined list of values.It's also possible for the application itself to define and assign its own Group Types (and instances).
+
+> The Group concept is correct choice when ORD resources need to be grouped through an explicit taxonomy, beyond the predefined taxonomy concepts from ORD (like Package). The advantage of groups over tags and labels is that their types and instance values can be defined, governed and listed.
 
 ### Examples
 

--- a/docs/spec-v1/diagrams/ord-document.md
+++ b/docs/spec-v1/diagrams/ord-document.md
@@ -617,6 +617,7 @@
   Capability --> "0..*" Group : partOfGroups
   IntegrationDependency --> "0..*" Group : partOfGroups
   Group --> "1" GroupType : groupTypeId
+  Group *-- "0..*" ExternalOrdId : members
   Tombstone --> "0..1" Group : groupId
   OrdResource --> "0..*" Group : partOfGroups
   click ApiResource href "#apiresource" "Go to ApiResource"
@@ -627,8 +628,19 @@
   click IntegrationDependency href "#integrationdependency" "Go to IntegrationDependency"
   click Group href "#group" "Go to Group"
   click GroupType href "#grouptype" "Go to GroupType"
+  click ExternalOrdId href "#externalordid" "Go to ExternalOrdId"
   click Tombstone href "#tombstone" "Go to Tombstone"
   click OrdResource href "#ordresource" "Go to OrdResource"
+  ```
+  
+
+## ExternalOrdId
+  ```mermaid
+  classDiagram
+  class ExternalOrdId
+  style ExternalOrdId stroke:#333,stroke-width:3px
+  Group *-- "0..*" ExternalOrdId : members
+  click Group href "#group" "Go to Group"
   ```
   
 

--- a/docs/spec-v1/examples/document-entity-types.md
+++ b/docs/spec-v1/examples/document-entity-types.md
@@ -8,12 +8,12 @@ description: Example documents for Document.
 ```json
 {
   "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.11",
   "description": "Example for entity types as they will be exposed by ODM",
   "policyLevels": ["sap:core:v1"],
   "packages": [
     {
-      "ordId": "sap.odm:package:OdmEntities:v1",
+      "ordId": "sap.xref:package:OdmEntities:v1",
       "title": "ODM Entities",
       "shortDescription": "This package includes all aligned ODM Entities",
       "description": "The ODM Entities are governed by the ODM Governance Board. They are semantically cross-LoB aligned and provide an unambiguous taxonomy",
@@ -24,7 +24,7 @@ description: Example documents for Document.
   ],
   "entityTypes": [
     {
-      "ordId": "sap.odm:entityType:BusinessPartner:v1",
+      "ordId": "sap.xref:entityType:BusinessPartner:v1",
       "localId": "BusinessPartner",
       "level": "aggregate",
       "title": "Business Partner",
@@ -32,7 +32,7 @@ description: Example documents for Document.
       "description": "A business partner is a person, an organization, or a group of persons or organizations in which a company has a business interest.",
       "version": "1.0.0",
       "lastUpdate": "2023-03-18T15:30:04+00:00",
-      "partOfPackage": "sap.odm:package:OdmEntities:v1",
+      "partOfPackage": "sap.xref:package:OdmEntities:v1",
       "visibility": "public",
       "links": [],
       "releaseStatus": "active",
@@ -40,7 +40,36 @@ description: Example documents for Document.
         {
           "ordId": "sap.vdm.sot:entityType:BusinessPartner:v1"
         }
-      ]
+      ],
+      "partOfGroups": []
+    },
+    {
+      "ordId": "sap.xref:entityType:BusinessArea:v1",
+      "localId": "BusinessArea",
+      "level": "aggregate",
+      "title": "Business Area",
+      "shortDescription": "A business area is an organizational unit used in external accounting that represents a specific business segment or area of responsibility in a company.",
+      "description": "<p>A business area is an organizational unit used in external accounting that represents a specific business segment or area of responsibility in a company.<br>Transactions in financial accounting are assigned to business areas.</p>",
+      "version": "1.0.1",
+      "partOfPackage": "sap.xref:package:BusinessObjectsInternal:v1",
+      "visibility": "internal",
+      "releaseStatus": "active",
+      "lastUpdate": "2024-12-13T14:57:56.614Z",
+      "partOfGroups": ["sap.xref:Process:sap:H2R"]
+    },
+    {
+      "ordId": "sap.xref:entityType:Company:v1",
+      "localId": "Company",
+      "level": "aggregate",
+      "title": "Company",
+      "shortDescription": "A company is a financially and legally independent, geographically unbound organizational center registered under business law.",
+      "description": "<p>A company is a financially and legally independent, geographically unbound organizational center registered under business law.</p>",
+      "version": "1.0.1",
+      "partOfPackage": "sap.xref:package:BusinessObjectsInternal:v1",
+      "visibility": "internal",
+      "releaseStatus": "active",
+      "lastUpdate": "2024-12-13T14:57:56.614Z",
+      "partOfGroups": ["sap.xref:Process:sap:H2R", "sap.xref:Process:sap:Retail"]
     }
   ]
 }

--- a/docs/spec-v1/examples/document-groups.md
+++ b/docs/spec-v1/examples/document-groups.md
@@ -1,0 +1,39 @@
+---
+title: document-groups
+description: Example documents for Document.
+---
+
+## Example File:  document-groups
+
+```json
+{
+  "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
+  "openResourceDiscovery": "1.12",
+  "description": "Example for group type and group assignments",
+  "policyLevels": [],
+  "groupTypes": [
+    {
+      "groupTypeId": "sap.xref:Process",
+      "title": "SAP defined Process (Sample only!)",
+      "description": "Processes that have been globally defined by SAP, e.g. Hire to Retire, Order to Cash, etc.",
+      "restrictDirection": "group-to-resource",
+      "restrictResourceType": ["entityType", "apiResource", "eventResource", "dataProduct"]
+    }
+  ],
+  "groups": [
+    {
+      "groupId": "sap.xref:Process:sap:H2R",
+      "groupTypeId": "sap.xref:Process",
+      "title": "Hire to Retire",
+      "members": ["sap.xref:entityType:Company:v1"]
+    },
+    {
+      "groupId": "sap.xref:Process:sap:Retail",
+      "groupTypeId": "sap.xref:Process",
+      "title": "Retail",
+      "members": [{ "ordId": "sap.xref:entityType:BusinessArea:v1"}, { "ordId": "sap.xref:entityType:Company:v1"}]
+    }
+  ]
+}
+
+```

--- a/docs/spec-v1/interfaces/Document.md
+++ b/docs/spec-v1/interfaces/Document.md
@@ -488,7 +488,7 @@ If an "identity / equals" relationship needs to be expressed, use the `correlati
 
 To learn more about the concept, see [Group Concept Documentation](../concepts/grouping-and-bundling#Groups).
 
-**Type**: Object(<a href="#group_groupid">groupId</a>, <a href="#group_grouptypeid">groupTypeId</a>, <a href="#group_title">title</a>, <a href="#group_description">description</a>)
+**Type**: Object(<a href="#group_groupid">groupId</a>, <a href="#group_grouptypeid">groupTypeId</a>, <a href="#group_title">title</a>, <a href="#group_description">description</a>, <a href="#group_members">members</a>)
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
@@ -496,6 +496,7 @@ To learn more about the concept, see [Group Concept Documentation](../concepts/g
 |<div className="interface-property-name anchor" id="group_grouptypeid">groupTypeId<br/><span className="mandatory">MANDATORY</span><a className="hash-link" href="#group_grouptypeid" title="Group.groupTypeId"></a></div>|<div className="interface-property-type">string</div>|<div className="interface-property-description">Group Type ID.<br/><br/>MUST match with the first two fragments of the own `groupId`.<hr/>**Association Target**: [groupTypeId](#group-type_grouptypeid))<br/>**Regex Pattern**: <code className="regex">^([a-z0-9-]+(?\:[.][a-z0-9-]+)\*)\:([a-zA-Z0-9._\\-\\/]+)$</code><br/>**Example Values**: <ul className="examples"><li>`"sap.foo:domain"`</li><li>`"sap.cap:service"`</li></ul></div>|
 |<div className="interface-property-name anchor" id="group_title">title<br/><span className="mandatory">MANDATORY</span><a className="hash-link" href="#group_title" title="Group.title"></a></div>|<div className="interface-property-type">string</div>|<div className="interface-property-description">Human readable title of the group assignment (for UI).<hr/>**Minimum Length**: `1`<br/>**Maximum Length**: `255`<br/>**Example Values**: <ul className="examples"><li>`"SAP S/4HANA Cloud"`</li></ul></div>|
 |<div className="interface-property-name anchor" id="group_description">description<br/><span className="optional">OPTIONAL</span><a className="hash-link" href="#group_description" title="Group.description"></a></div>|<div className="interface-property-type">string</div>|<div className="interface-property-description">Full description, notated in [CommonMark](https://spec.commonmark.org/) (Markdown).<br/><br/>The description SHOULD not be excessive in length and is not meant to provide full documentation.<br/>Detailed documentation SHOULD be attached as (typed) links.<hr/>**Minimum Length**: `1`<br/>**Example Values**: <ul className="examples"><li>`"SAP S/4HANA Cloud, our next generation cloud ERP suite designed for\nin-memory computing, acts as a digital core, connecting your\nenterprise with people, business networks, the Internet of Things,\nBig Data, and more.\n"`</li></ul></div>|
+|<div className="interface-property-name anchor" id="group_members">members<br/><span className="optional">OPTIONAL</span> <span className="feature-status-beta" title="This feature is BETA status and subject to potential changes.">BETA</span><a className="hash-link" href="#group_members" title="Group.members"></a></div>|<div className="interface-property-type">Array&lt;[External ORD ID](#external-ord-id)&gt;</div>|<div className="interface-property-description">List of members of the group, complementing the reverse `partOfGroups` assignment.<br/>The members are defined as a list of [ORD IDs](../../spec-v1/#ord-id).<br/>This list allows a group to define its members, instead of ORD resources stating their membership via `partOfGroups`.<br/>Which direction should be used depends on which sides knows it first-hand.<br/>The ORD Provider SHOULD offer convenience to calculate the reverse relationships on both sides, ideally as a merged and consolidated (duplicate-free) bi-directional relation.<hr/><strong>Introduced in Version</strong>: 1.13.0<br/>**Example Values**: <ul className="examples"><li>`[{"ordId":"sap.s4:apiResource:API_BILL_OF_MATERIAL_SRV:v1"},{"ordId":"sap.s4:apiResource:API_SALES_ORDER_SRV:v1"}]`</li></ul></div>|
 
 
 ###### Example Values:
@@ -519,13 +520,15 @@ Group Types can be defined centrally (ownership by authority namespace) or decen
 
 To learn more about the concept, see [Group Concept Documentation](../concepts/grouping-and-bundling#Groups).
 
-**Type**: Object(<a href="#group-type_grouptypeid">groupTypeId</a>, <a href="#group-type_title">title</a>, <a href="#group-type_description">description</a>)
+**Type**: Object(<a href="#group-type_grouptypeid">groupTypeId</a>, <a href="#group-type_title">title</a>, <a href="#group-type_description">description</a>, <a href="#group-type_restrictdirection">restrictDirection</a>, <a href="#group-type_restrictresourcetype">restrictResourceType</a>)
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
 |<div className="interface-property-name anchor" id="group-type_grouptypeid">groupTypeId<br/><span className="mandatory">MANDATORY</span><a className="hash-link" href="#group-type_grouptypeid" title="GroupType.groupTypeId"></a></div>|<div className="interface-property-type">string</div>|<div className="interface-property-description">GroupType ID, which MUST be a valid [Concept ID](../../spec-v1/#concept-id).<hr/>**Regex Pattern**: <code className="regex">^([a-z0-9-]+(?\:[.][a-z0-9-]+)\*)\:([a-zA-Z0-9._\\-\\/]+)$</code><br/>**Example Values**: <ul className="examples"><li>`"sap.foo:domain"`</li><li>`"sap.cap:service"`</li></ul></div>|
 |<div className="interface-property-name anchor" id="group-type_title">title<br/><span className="mandatory">MANDATORY</span><a className="hash-link" href="#group-type_title" title="GroupType.title"></a></div>|<div className="interface-property-type">string</div>|<div className="interface-property-description">Human readable title of the group type.<hr/>**Minimum Length**: `1`<br/>**Maximum Length**: `255`<br/>**Example Values**: <ul className="examples"><li>`"SAP S/4HANA Cloud"`</li></ul></div>|
 |<div className="interface-property-name anchor" id="group-type_description">description<br/><span className="optional">OPTIONAL</span><a className="hash-link" href="#group-type_description" title="GroupType.description"></a></div>|<div className="interface-property-type">string</div>|<div className="interface-property-description">Full description, notated in [CommonMark](https://spec.commonmark.org/) (Markdown).<br/><br/>The description SHOULD not be excessive in length and is not meant to provide full documentation.<br/>Detailed documentation SHOULD be attached as (typed) links.<hr/>**Minimum Length**: `1`<br/>**Example Values**: <ul className="examples"><li>`"SAP S/4HANA Cloud, our next generation cloud ERP suite designed for\nin-memory computing, acts as a digital core, connecting your\nenterprise with people, business networks, the Internet of Things,\nBig Data, and more.\n"`</li></ul></div>|
+|<div className="interface-property-name anchor" id="group-type_restrictdirection">restrictDirection<br/><span className="optional">OPTIONAL</span> <span className="feature-status-beta" title="This feature is BETA status and subject to potential changes.">BETA</span><a className="hash-link" href="#group-type_restrictdirection" title="GroupType.restrictDirection"></a></div>|<div className="interface-property-type">string</div>|<div className="interface-property-description">Optionally restricts the direction of the group assignments for this group type.<hr/>**Allowed Values**: <ul><li><p>`"resource-to-group"`: The resource is assigned to the group.</p></li><li><p>`"group-to-resource"`: The group is assigned to the resource.</p></li></ul><br/><strong>Introduced in Version</strong>: 1.13.0</div>|
+|<div className="interface-property-name anchor" id="group-type_restrictresourcetype">restrictResourceType<br/><span className="optional">OPTIONAL</span> <span className="feature-status-beta" title="This feature is BETA status and subject to potential changes.">BETA</span><a className="hash-link" href="#group-type_restrictresourcetype" title="GroupType.restrictResourceType"></a></div>|<div className="interface-property-type">Array&lt;string&gt;</div>|<div className="interface-property-description">Optionally restricts group assignments (of this group type) to ORD resource types.<hr/><strong>Introduced in Version</strong>: 1.13.0</div>|
 
 
 ###### Example Values:
@@ -535,7 +538,11 @@ To learn more about the concept, see [Group Concept Documentation](../concepts/g
 {
   "groupTypeId": "sap.cds:service",
   "title": "CAP Service",
-  "description": "Description of the CDS Service concept and how its correctly used for grouping..."
+  "description": "Description of the CDS Service concept and how its correctly used for grouping...",
+  "restrictResourceType": [
+    "apiResource",
+    "eventResource"
+  ]
 }
 ```
 
@@ -989,6 +996,32 @@ Duplicate labels will be merged by the ORD aggregator according to the following
 ```
 
 
+### External ORD ID
+
+<span className="feature-status-beta" title="This feature is BETA status and subject to potential changes.">BETA</span> 
+
+An external ORD ID is a reference to an ORD resource that is defined by a different ORD Provider.
+The format of the external ORD ID is the same as the [ORD ID](../../spec-v1/#ord-id) format.
+If the reference points to a resource particular to a tenant, the tenant ID MUST be provided, too.
+
+**Type**: Object(<a href="#external-ord-id_ordid">ordId</a>, <a href="#external-ord-id_systeminstancecorrelationid">systemInstanceCorrelationId</a>)
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+|<div className="interface-property-name anchor" id="external-ord-id_ordid">ordId<br/><span className="optional">OPTIONAL</span><a className="hash-link" href="#external-ord-id_ordid" title="ExternalOrdId.ordId"></a></div>|<div className="interface-property-type">string</div>|<div className="interface-property-description"><hr/>**Regex Pattern**: <code className="regex">^([a-z0-9]+(?\:[.][a-z0-9]+)\*)\:(package\|consumptionBundle\|product\|vendor\|apiResource\|eventResource\|capability\|entityType\|integrationDependency\|dataProduct)\:([a-zA-Z0-9._\\-]+)\:(v0\|v[1-9][0-9]\*\|)?$</code></div>|
+|<div className="interface-property-name anchor" id="external-ord-id_systeminstancecorrelationid">systemInstanceCorrelationId<br/><span className="optional">OPTIONAL</span><a className="hash-link" href="#external-ord-id_systeminstancecorrelationid" title="ExternalOrdId.systemInstanceCorrelationId"></a></div>|<div className="interface-property-type">string</div>|<div className="interface-property-description">Optionally define the system instance that the external ORD ID is related to.<br/>This is done by proving a [Correlation ID](../../spec-v1/#correlation-id), as system instances have no own ORD ID.<br/>Which correlation ID and namespace / concept to use depends on which systems have the authority to create and know the system instance / tenant IDs.<hr/>**Regex Pattern**: <code className="regex">^([a-z0-9]+(?\:[.][a-z0-9]+)\*)\:([a-zA-Z0-9._\\-\\/]+)\:([a-zA-Z0-9._\\-\\/]+)$</code><br/>**Maximum Length**: `255`<br/>**Example Values**: <ul className="examples"><li>`"sap.cld:tenant:741234567"`</li></ul></div>|
+
+
+###### Example Values:
+
+
+```js
+{
+  "ordId": "sap.s4:apiResource:API_BILL_OF_MATERIAL_SRV:v1"
+}
+```
+
+
 ### Documentation Labels
 
 Generic documentation labels that can be applied to most ORD information.
@@ -1072,7 +1105,7 @@ or through a defined and known `implementationStandard` that can resolve the `lo
 At SAP, the metadata about entity types could be retrieved via the CSN_EXPOSURE service.
 To indicate this, the service needs to be implemented and described in ORD with `implementationStandard` set to `sap:csn-exposure:v1`).
 
-ODM 2.0 relies on the entity type mappings and uses the mapping to express the relationship of an API to the
+ODM 2.0 relies on the entity type mappings and uses the the mapping to express the relationship of an API to the
 corresponding ODM entity. ORD consumers like SAP Business Accelerator Hub consume the mapping to make the relationships navigate-able for customers.
 
 **Type**: Object(<a href="#entity-type-mapping_apimodelselectors">apiModelSelectors</a>, <a href="#entity-type-mapping_entitytypetargets">entityTypeTargets</a>)

--- a/examples/documents/document-entity-types.json
+++ b/examples/documents/document-entity-types.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.11",
   "description": "Example for entity types as they will be exposed by ODM",
   "policyLevels": ["sap:core:v1"],
   "packages": [
     {
-      "ordId": "sap.odm:package:OdmEntities:v1",
+      "ordId": "sap.xref:package:OdmEntities:v1",
       "title": "ODM Entities",
       "shortDescription": "This package includes all aligned ODM Entities",
       "description": "The ODM Entities are governed by the ODM Governance Board. They are semantically cross-LoB aligned and provide an unambiguous taxonomy",
@@ -16,7 +16,7 @@
   ],
   "entityTypes": [
     {
-      "ordId": "sap.odm:entityType:BusinessPartner:v1",
+      "ordId": "sap.xref:entityType:BusinessPartner:v1",
       "localId": "BusinessPartner",
       "level": "aggregate",
       "title": "Business Partner",
@@ -24,7 +24,7 @@
       "description": "A business partner is a person, an organization, or a group of persons or organizations in which a company has a business interest.",
       "version": "1.0.0",
       "lastUpdate": "2023-03-18T15:30:04+00:00",
-      "partOfPackage": "sap.odm:package:OdmEntities:v1",
+      "partOfPackage": "sap.xref:package:OdmEntities:v1",
       "visibility": "public",
       "links": [],
       "releaseStatus": "active",
@@ -32,7 +32,36 @@
         {
           "ordId": "sap.vdm.sot:entityType:BusinessPartner:v1"
         }
-      ]
+      ],
+      "partOfGroups": []
+    },
+    {
+      "ordId": "sap.xref:entityType:BusinessArea:v1",
+      "localId": "BusinessArea",
+      "level": "aggregate",
+      "title": "Business Area",
+      "shortDescription": "A business area is an organizational unit used in external accounting that represents a specific business segment or area of responsibility in a company.",
+      "description": "<p>A business area is an organizational unit used in external accounting that represents a specific business segment or area of responsibility in a company.<br>Transactions in financial accounting are assigned to business areas.</p>",
+      "version": "1.0.1",
+      "partOfPackage": "sap.xref:package:BusinessObjectsInternal:v1",
+      "visibility": "internal",
+      "releaseStatus": "active",
+      "lastUpdate": "2024-12-13T14:57:56.614Z",
+      "partOfGroups": ["sap.xref:Process:sap:H2R"]
+    },
+    {
+      "ordId": "sap.xref:entityType:Company:v1",
+      "localId": "Company",
+      "level": "aggregate",
+      "title": "Company",
+      "shortDescription": "A company is a financially and legally independent, geographically unbound organizational center registered under business law.",
+      "description": "<p>A company is a financially and legally independent, geographically unbound organizational center registered under business law.</p>",
+      "version": "1.0.1",
+      "partOfPackage": "sap.xref:package:BusinessObjectsInternal:v1",
+      "visibility": "internal",
+      "releaseStatus": "active",
+      "lastUpdate": "2024-12-13T14:57:56.614Z",
+      "partOfGroups": ["sap.xref:Process:sap:H2R", "sap.xref:Process:sap:Retail"]
     }
   ]
 }

--- a/examples/documents/document-groups.json
+++ b/examples/documents/document-groups.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
+  "openResourceDiscovery": "1.12",
+  "description": "Example for group type and group assignments",
+  "policyLevels": [],
+  "groupTypes": [
+    {
+      "groupTypeId": "sap.xref:Process",
+      "title": "SAP defined Process (Sample only!)",
+      "description": "Processes that have been globally defined by SAP, e.g. Hire to Retire, Order to Cash, etc.",
+      "restrictDirection": "group-to-resource",
+      "restrictResourceType": ["entityType", "apiResource", "eventResource", "dataProduct"]
+    }
+  ],
+  "groups": [
+    {
+      "groupId": "sap.xref:Process:sap:H2R",
+      "groupTypeId": "sap.xref:Process",
+      "title": "Hire to Retire",
+      "members": ["sap.xref:entityType:Company:v1"]
+    },
+    {
+      "groupId": "sap.xref:Process:sap:Retail",
+      "groupTypeId": "sap.xref:Process",
+      "title": "Retail",
+      "members": [{ "ordId": "sap.xref:entityType:BusinessArea:v1"}, { "ordId": "sap.xref:entityType:Company:v1"}]
+    }
+  ],
+  "entityTypes": [{
+    "ordId": "sap.xref:entityType:Company:v1",
+    "partOfGroups": ["sap.xref:Process:sap:Retail"]
+  }]
+}

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -3900,6 +3900,38 @@ definitions:
       # documentationLabels:
       #   <<: *documentationLabels
 
+      restrictDirection:
+        type: string
+        oneOf:
+          - const: "resource-to-group"
+            description: |-
+              The resource is assigned to the group.
+          - const: "group-to-resource"
+            description: |-
+              The group is assigned to the resource.
+        description: |-
+          Optionally restricts the direction of the group assignments for this group type.
+        x-introduced-in-version: "1.13.0"
+        x-feature-status: beta
+
+      restrictResourceType:
+        type: array
+        description: |-
+          Optionally restricts group assignments (of this group type) to ORD resource types.
+        items:
+          type: string
+          enum:
+            - "package"
+            - "consumptionBundle"
+            - "apiResource"
+            - "eventResource"
+            - "capability"
+            - "entityType"
+            - "integrationDependency"
+            - "dataProduct"
+        x-introduced-in-version: "1.13.0"
+        x-feature-status: beta
+
     required:
       - groupTypeId
       - title
@@ -3907,6 +3939,7 @@ definitions:
       - groupTypeId: "sap.cds:service"
         title: "CAP Service"
         description: "Description of the CDS Service concept and how its correctly used for grouping..."
+        restrictResourceType: ["apiResource", "eventResource"]
 
   ############################################################################################################
 
@@ -3959,6 +3992,22 @@ definitions:
       description:
         <<: *description
 
+      members:
+        type: array
+        x-introduced-in-version: "1.13.0"
+        x-feature-status: beta
+        # TODO: Define x-ums-reverse-relationship later
+        description: |-
+          List of members of the group, complementing the reverse `partOfGroups` assignment.
+          The members are defined as a list of [ORD IDs](../../spec-v1/#ord-id).
+          This list allows a group to define its members, instead of ORD resources stating their membership via `partOfGroups`.
+          Which direction should be used depends on which sides knows it first-hand.
+          The ORD Provider SHOULD offer convenience to calculate the reverse relationships on both sides, ideally as a merged and consolidated (duplicate-free) bi-directional relation.
+        items:
+          $ref: "#/definitions/ExternalOrdId"
+        examples:
+          - [{"ordId": "sap.s4:apiResource:API_BILL_OF_MATERIAL_SRV:v1"}, {"ordId": "sap.s4:apiResource:API_SALES_ORDER_SRV:v1"}]
+
     required:
       - groupId
       - groupTypeId
@@ -3967,6 +4016,47 @@ definitions:
       - groupId: "sap.cap:service:customer.incidents:incidents.IncidentsService"
         groupTypeId: "sap.cap:service"
         title: "Incidents Service"
+
+############################################################################################################
+
+  ExternalOrdId:
+    title: External ORD ID
+    type: object
+    description: |-
+      An external ORD ID is a reference to an ORD resource that is defined by a different ORD Provider.
+      The format of the external ORD ID is the same as the [ORD ID](../../spec-v1/#ord-id) format.
+      If the reference points to a resource particular to a tenant, the tenant ID MUST be provided, too.
+    x-introduced-in-version: "1.13.0"
+    x-feature-status: beta
+    x-ums-type: 'embedded'
+    properties:
+      ordId:
+        type: string
+        pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):(package|consumptionBundle|product|vendor|apiResource|eventResource|capability|entityType|integrationDependency|dataProduct):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*|)?$
+        # TODO: Enable this again and fix UMS missing x-ums-implements instructions
+        # x-association-target:
+        #   - "#/definitions/Package/ordId"
+        #   - "#/definitions/ConsumptionBundle/ordId"
+        #   - "#/definitions/Product/ordId"
+        #   - "#/definitions/Vendor/ordId"
+        #   - "#/definitions/ApiResource/ordId"
+        #   - "#/definitions/EventResource/ordId"
+        #   - "#/definitions/Capability/ordId"
+        #   - "#/definitions/EntityType/ordId"
+        #   - "#/definitions/IntegrationDependency/ordId"
+        #   - "#/definitions/DataProduct/ordId"
+      systemInstanceCorrelationId:
+        <<: *correlationId
+        type: string
+        description: |-
+          Optionally define the system instance that the external ORD ID is related to.
+          This is done by proving a [Correlation ID](../../spec-v1/#correlation-id), as system instances have no own ORD ID.
+          Which correlation ID and namespace / concept to use depends on which systems have the authority to create and know the system instance / tenant IDs.
+        examples:
+          - "sap.cld:tenant:741234567"
+      # isolationContext: # TODO: Add this once isolationContext is introduced
+    examples:
+      - { "ordId": "sap.s4:apiResource:API_BILL_OF_MATERIAL_SRV:v1" }
 
   ############################################################################################################
 

--- a/static/img/group-concept-overview.drawio.svg
+++ b/static/img/group-concept-overview.drawio.svg
@@ -1,161 +1,247 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="551px" height="41px" viewBox="-0.5 -0.5 551 41" content="&lt;mxfile&gt;&lt;diagram id=&quot;2YkCrQNGzRfVnGFq4Dh8&quot; name=&quot;Page-1&quot;&gt;5Vhdb5swFP01PCYCbOfjcU277GFTp2bSnh1swJrByDhf/fUzwQQcSJcp0FQbkQI+tg++55h7SRywSPZLibP4myCUO75L9g54dHzf88BMnwrkUCLIAyUQSUbMoBpYsVdqQNegG0Zobg1UQnDFMhsMRJrSQFkYllLs7GGh4PZdMxzRFrAKMG+jPxlRcYlOZm6Nf6Esis2dkWs6ElyNNUAeYyJ2DQg8OWAhhVDlVbJfUF5oV8lSzvt8ofe0LklTdc2EiVmGOlShUaIjNc1UpPr0EKuE65anL9v85pa52MjAUBgvFZYRNaNgCRXkjWlmTUsqEqrkQQ+QlGPFtrbM2LgVncbVEekLE1R3gNOSYov5xpC643HaGfVXvNbb1AoXcxal+jrQ4VKpgS2Viul98Ml0JIyQguNB0py94vWRz9XtTLBUHdeNHhz02CmdEb/gpPuufWv4rL1hybWvQoLTSnXzRPll62o9Dff3Ytk1sWdxjjzfJhBhmGuHz+04LfAqh2b/g0Mjd4z86XQAi0b+O3hUkTZM0jKp53ApxSa7n1dXG9Nh61teQQBsWb1+Hidkk3oDWAVaTj2/6G/3hZoUfW6WdjAllBildzFTdJXhYy7f6ep9Zf5vOXFR3qqGH+zmrq6jXuVZ3Kih0L29GMyHqHawXe3QvapdJeaHTKbzHpMpRL6dTEf9PKGjc1Y4RDb1Wi55/5hFzTeSGy05dwQM4Ug7a0ZFZftxyNoJ86NXt/mfHh4wQz3Vs7Mi6Q5gDWw50/3O8VdlLGScLwQX8jgXhKj4aDxXUvyijZ7J8ShmiFQ18PLopyD64H4VEV1S1+3c+reIvMbBjIAukX0AISL9iAnhu4mpm/UP9XJn1/92gKff&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: transparent; background-color: transparent;" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="552px" height="80px" viewBox="-0.5 -0.5 552 80" content="&lt;mxfile&gt;&lt;diagram id=&quot;2YkCrQNGzRfVnGFq4Dh8&quot; name=&quot;Page-1&quot;&gt;5VhRb5swEP41eUyEMSTwuKZd97CpUztp26MTDFgDjIzThP76mXAuGOiUttBmWyIl9vl8+L7Pd2czw+v0cC1IHn/hAU1mthUcZvhyZttL5KvfSlDWAtvHtSASLKhFqBHcsQcKQgukOxbQwlCUnCeS5aZwy7OMbqUhI0LwvakW8sR8ak4ieKLVCO62JKE9te8skDG45bW0P1EWxfBk14KBlGhdEBQxCfi+JcJXM7wWnMu6lR7WNKmg07DU8z4+Mfq4LkEzecqEJSxDlto1GihPoZvxTP1dxDJNVA+pZt8+PLLgO7EFE8ClJCKioOXUosp4axqs6ZrylEpRKgVBEyLZvQkzAbaiR73GI9UAp4YdXNUm7kmy04wuFtmg15/JRu1Sw12SsChT7a1ylwoluKdCMrUPPsBAyoKgsnEhaMEeyOZoz1L9nLNMHtftXszcy0HoAPzKJj0M7VuwZ+wNA66DdslZadR1RNW9k/EE21+rZTeGkWFzjmzTAA/DQjHcpeNxgScx5P0PDM2thWuvVhNQNLffgCNttEWSgknehNeC7/L34CrkmdRpypqWOAdjE2M0Tmy5plE0AW+4R9vNrfq1bink6y5zis4soAHAvo+ZpHc5OSb2varkJxaDHuxPwqsLeml2901RRbpUxq2C6livrwz+FKXP6Zc+971KnwbzLDOrP2aAuraZWefjROi8a9WZIrWiHkvoH6OofTx5JSVdRvAUjPSzZlSVuW9l3k+YfzczKniw545UzzpF0pqCGueZSVtBJsofFbQLV3d/tscuD4B73Suh99Jkj8dO9sepH4QgZUsB9siTVNi+WVa9ziWwG1R/0laN+vEv5szthVNK0w0VxXkEk95TY+Q52/OXZoYaJ+1hx7S6miK2lj2ezue4MB5JKuX5GJuX5ZGOC6jD0hQnenTOLzTGDCXPX00SSsikfu5OQJLT42j4nvys21bIkmTNEy6Oc3HoVl8lL6Tgv2hrZHn8wB25Ja8/49zbbPx+F7d+PQF0rcET2mtA3pCtF+AhkFVKdtxgHDAd583AVN3m5XK9s5sX9PjqNw==&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
-        <path d="M 120 20 L 213.63 20" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 218.88 20 L 211.88 23.5 L 213.63 20 L 211.88 16.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 7px; margin-left: 196px;">
-                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
-                                0..n
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="196" y="10" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    0..n
-                </text>
-            </switch>
+        <g>
+            <path d="M 120 20 L 213.63 20" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 218.88 20 L 211.88 23.5 L 213.63 20 L 211.88 16.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 7px; margin-left: 143px;">
-                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
-                                0..n
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 6px; margin-left: 195px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; background-color: #ffffff; ">
+                                <div style="display: inline-block; font-size: 11px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
+                                    0..n
+                                </div>
                             </div>
                         </div>
-                    </div>
-                </foreignObject>
-                <text x="143" y="10" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    0..n
-                </text>
-            </switch>
+                    </foreignObject>
+                    <text x="195" y="10" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
+                        0..n
+                    </text>
+                </switch>
+            </g>
         </g>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 31px; margin-left: 164px;">
-                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
-                                partOfGroup
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 6px; margin-left: 142px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; background-color: #ffffff; ">
+                                <div style="display: inline-block; font-size: 11px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
+                                    0..n
+                                </div>
                             </div>
                         </div>
-                    </div>
-                </foreignObject>
-                <text x="164" y="34" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    partOfGroup
-                </text>
-            </switch>
+                    </foreignObject>
+                    <text x="142" y="10" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
+                        0..n
+                    </text>
+                </switch>
+            </g>
         </g>
-        <rect x="0" y="0" width="120" height="40" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 20px; margin-left: 1px;">
-                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
-                                ORD Resource
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 30px; margin-left: 164px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; background-color: #ffffff; ">
+                                <div style="display: inline-block; font-size: 11px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
+                                    partOfGroup
+                                </div>
                             </div>
                         </div>
-                    </div>
-                </foreignObject>
-                <text x="60" y="24" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    ORD Resource
-                </text>
-            </switch>
+                    </foreignObject>
+                    <text x="164" y="34" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
+                        partOfGroup
+                    </text>
+                </switch>
+            </g>
         </g>
-        <path d="M 340 20 L 423.63 20" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 428.88 20 L 421.88 23.5 L 423.63 20 L 421.88 16.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 8px; margin-left: 359px;">
-                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
-                                0..n
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="359" y="11" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    0..n
-                </text>
-            </switch>
+        <g>
+            <rect x="0" y="0" width="120" height="40" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 8px; margin-left: 414px;">
-                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
-                                1
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 20px; margin-left: 1px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    ORD Resource
+                                </div>
                             </div>
                         </div>
-                    </div>
-                </foreignObject>
-                <text x="414" y="11" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    1
-                </text>
-            </switch>
+                    </foreignObject>
+                    <text x="60" y="24" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        ORD Resource
+                    </text>
+                </switch>
+            </g>
         </g>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 31px; margin-left: 381px;">
-                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
-                                groupType
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="381" y="34" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    groupType
-                </text>
-            </switch>
+        <g>
+            <path d="M 340 20 L 423.63 20" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 428.88 20 L 421.88 23.5 L 423.63 20 L 421.88 16.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
-        <rect x="220" y="0" width="120" height="40" fill="#f5f5f5" stroke="#666666" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 20px; margin-left: 221px;">
-                        <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
-                                Group
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 7px; margin-left: 358px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; background-color: #ffffff; ">
+                                <div style="display: inline-block; font-size: 11px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
+                                    0..n
+                                </div>
                             </div>
                         </div>
-                    </div>
-                </foreignObject>
-                <text x="280" y="24" fill="#333333" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    Group
-                </text>
-            </switch>
+                    </foreignObject>
+                    <text x="358" y="11" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
+                        0..n
+                    </text>
+                </switch>
+            </g>
         </g>
-        <rect x="430" y="0" width="120" height="40" fill="#bac8d3" stroke="#23445d" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 20px; margin-left: 431px;">
-                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
-                                Group Type
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 7px; margin-left: 414px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; background-color: #ffffff; ">
+                                <div style="display: inline-block; font-size: 11px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
+                                    1
+                                </div>
                             </div>
                         </div>
-                    </div>
-                </foreignObject>
-                <text x="490" y="24" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    Group Type
-                </text>
-            </switch>
+                    </foreignObject>
+                    <text x="414" y="11" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
+                        1
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 30px; margin-left: 380px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; background-color: #ffffff; ">
+                                <div style="display: inline-block; font-size: 11px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
+                                    groupType
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="380" y="34" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
+                        groupType
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 280 40 L 280 60 Q 280 70 270 70 L 70 70 Q 60 70 60 60 L 60 46.37" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 60 41.12 L 63.5 48.12 L 60 46.37 L 56.5 48.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 60px; margin-left: 164px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; background-color: #ffffff; ">
+                                <div style="display: inline-block; font-size: 11px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
+                                    members
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="164" y="64" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
+                        members
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 49px; margin-left: 267px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; background-color: #ffffff; ">
+                                <div style="display: inline-block; font-size: 11px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
+                                    0..n
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="267" y="52" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
+                        0..n
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 50px; margin-left: 76px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; background-color: #ffffff; ">
+                                <div style="display: inline-block; font-size: 11px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
+                                    0..n
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="76" y="53" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
+                        0..n
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="220" y="0" width="120" height="40" fill="#f5f5f5" stroke="#666666" pointer-events="all" style="fill: light-dark(rgb(245, 245, 245), rgb(26, 26, 26)); stroke: light-dark(rgb(102, 102, 102), rgb(149, 149, 149));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 20px; margin-left: 221px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #333333; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#333333, #c1c1c1); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    Group
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="280" y="24" fill="#333333" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        Group
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="430" y="0" width="120" height="40" fill="#bac8d3" stroke="#23445d" pointer-events="all" style="fill: light-dark(rgb(186, 200, 211), rgb(57, 69, 78)); stroke: light-dark(rgb(35, 68, 93), rgb(160, 188, 210));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 20px; margin-left: 431px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    Group Type
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="490" y="24" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        Group Type
+                    </text>
+                </switch>
+            </g>
         </g>
     </g>
     <switch>
         <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
-        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+        <a transform="translate(0,-5)" xlink:href="https://www.drawio.com/doc/faq/svg-export-text-problems" target="_blank">
             <text text-anchor="middle" font-size="10px" x="50%" y="100%">
                 Text is not SVG - cannot display
             </text>

--- a/static/spec-v1/interfaces/Document.schema.json
+++ b/static/spec-v1/interfaces/Document.schema.json
@@ -5253,6 +5253,41 @@
           "examples": [
             "SAP S/4HANA Cloud, our next generation cloud ERP suite designed for\nin-memory computing, acts as a digital core, connecting your\nenterprise with people, business networks, the Internet of Things,\nBig Data, and more.\n"
           ]
+        },
+        "restrictDirection": {
+          "type": "string",
+          "oneOf": [
+            {
+              "const": "resource-to-group",
+              "description": "The resource is assigned to the group."
+            },
+            {
+              "const": "group-to-resource",
+              "description": "The group is assigned to the resource."
+            }
+          ],
+          "description": "Optionally restricts the direction of the group assignments for this group type.",
+          "x-introduced-in-version": "1.13.0",
+          "x-feature-status": "beta"
+        },
+        "restrictResourceType": {
+          "type": "array",
+          "description": "Optionally restricts group assignments (of this group type) to ORD resource types.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "package",
+              "consumptionBundle",
+              "apiResource",
+              "eventResource",
+              "capability",
+              "entityType",
+              "integrationDependency",
+              "dataProduct"
+            ]
+          },
+          "x-introduced-in-version": "1.13.0",
+          "x-feature-status": "beta"
         }
       },
       "required": [
@@ -5263,7 +5298,11 @@
         {
           "groupTypeId": "sap.cds:service",
           "title": "CAP Service",
-          "description": "Description of the CDS Service concept and how its correctly used for grouping..."
+          "description": "Description of the CDS Service concept and how its correctly used for grouping...",
+          "restrictResourceType": [
+            "apiResource",
+            "eventResource"
+          ]
         }
       ]
     },
@@ -5309,6 +5348,25 @@
           "examples": [
             "SAP S/4HANA Cloud, our next generation cloud ERP suite designed for\nin-memory computing, acts as a digital core, connecting your\nenterprise with people, business networks, the Internet of Things,\nBig Data, and more.\n"
           ]
+        },
+        "members": {
+          "type": "array",
+          "x-introduced-in-version": "1.13.0",
+          "x-feature-status": "beta",
+          "description": "List of members of the group, complementing the reverse `partOfGroups` assignment.\nThe members are defined as a list of [ORD IDs](../../spec-v1/#ord-id).\nThis list allows a group to define its members, instead of ORD resources stating their membership via `partOfGroups`.\nWhich direction should be used depends on which sides knows it first-hand.\nThe ORD Provider SHOULD offer convenience to calculate the reverse relationships on both sides, ideally as a merged and consolidated (duplicate-free) bi-directional relation.",
+          "items": {
+            "$ref": "#/definitions/ExternalOrdId"
+          },
+          "examples": [
+            [
+              {
+                "ordId": "sap.s4:apiResource:API_BILL_OF_MATERIAL_SRV:v1"
+              },
+              {
+                "ordId": "sap.s4:apiResource:API_SALES_ORDER_SRV:v1"
+              }
+            ]
+          ]
         }
       },
       "required": [
@@ -5321,6 +5379,33 @@
           "groupId": "sap.cap:service:customer.incidents:incidents.IncidentsService",
           "groupTypeId": "sap.cap:service",
           "title": "Incidents Service"
+        }
+      ]
+    },
+    "ExternalOrdId": {
+      "title": "External ORD ID",
+      "type": "object",
+      "description": "An external ORD ID is a reference to an ORD resource that is defined by a different ORD Provider.\nThe format of the external ORD ID is the same as the [ORD ID](../../spec-v1/#ord-id) format.\nIf the reference points to a resource particular to a tenant, the tenant ID MUST be provided, too.",
+      "x-introduced-in-version": "1.13.0",
+      "x-feature-status": "beta",
+      "properties": {
+        "ordId": {
+          "type": "string",
+          "pattern": "^([a-z0-9]+(?:[.][a-z0-9]+)*):(package|consumptionBundle|product|vendor|apiResource|eventResource|capability|entityType|integrationDependency|dataProduct):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*|)?$"
+        },
+        "systemInstanceCorrelationId": {
+          "type": "string",
+          "pattern": "^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\\-\\/]+):([a-zA-Z0-9._\\-\\/]+)$",
+          "maxLength": 255,
+          "description": "Optionally define the system instance that the external ORD ID is related to.\nThis is done by proving a [Correlation ID](../../spec-v1/#correlation-id), as system instances have no own ORD ID.\nWhich correlation ID and namespace / concept to use depends on which systems have the authority to create and know the system instance / tenant IDs.",
+          "examples": [
+            "sap.cld:tenant:741234567"
+          ]
+        }
+      },
+      "examples": [
+        {
+          "ordId": "sap.s4:apiResource:API_BILL_OF_MATERIAL_SRV:v1"
         }
       ]
     },

--- a/static/spec-v1/interfaces/ums/MetadataType/externalordid.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/externalordid.yaml
@@ -1,0 +1,31 @@
+apiVersion: 'metadata-service.resource.api.sap/v6alpha1'
+type: 'MetadataType'
+metadata:
+  name: 'externalordid'
+  path: '/sap/core/ucl/metadata/ord/v1'
+  labels: {}
+spec:
+  typeName: 'ExternalOrdId'
+  key:
+    - 'id'
+  visibility: 'public'
+  embedded: true
+  description: "An external ORD ID is a reference to an ORD resource that is defined by a different ORD Provider.\nThe format of the external ORD ID is the same as the [ORD ID](../../spec-v1/#ord-id) format.\nIf the reference points to a resource particular to a tenant, the tenant ID MUST be provided, too."
+  metadataProperties:
+    - name: 'id'
+      type: 'guid'
+      mandatory: true
+      unique: true
+      description: 'UMS ID (globally unique), used for relations.'
+    - name: 'ordId'
+      type: 'string'
+      constraints:
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(package|consumptionBundle|product|vendor|apiResource|eventResource|capability|entityType|integrationDependency|dataProduct):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*|)?$'
+    - name: 'systemInstanceCorrelationId'
+      type: 'string'
+      description: "Optionally define the system instance that the external ORD ID is related to.\nThis is done by proving a [Correlation ID](../../spec-v1/#correlation-id), as system instances have no own ORD ID.\nWhich correlation ID and namespace / concept to use depends on which systems have the authority to create and know the system instance / tenant IDs."
+      constraints:
+        maxLength: 255
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+):([a-zA-Z0-9._\-\/]+)$'
+  customTypeDefinitions: []
+  metadataRelations: []

--- a/static/spec-v1/interfaces/ums/MetadataType/group.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/group.yaml
@@ -52,6 +52,10 @@ spec:
       mandatory: true
       reverseRelation:
         relationPropertyName: 'groups'
+    - propertyName: 'members'
+      relatedTypeName: 'ExternalOrdId'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      description: "List of members of the group, complementing the reverse `partOfGroups` assignment.\nThe members are defined as a list of [ORD IDs](../../spec-v1/#ord-id).\nThis list allows a group to define its members, instead of ORD resources stating their membership via `partOfGroups`.\nWhich direction should be used depends on which sides knows it first-hand.\nThe ORD Provider SHOULD offer convenience to calculate the reverse relationships on both sides, ideally as a merged and consolidated (duplicate-free) bi-directional relation."
     - propertyName: 'apiResourceMembers'
       relatedTypeName: 'ApiResource'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'

--- a/static/spec-v1/interfaces/ums/MetadataType/grouptype.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/grouptype.yaml
@@ -35,6 +35,13 @@ spec:
       description: "Full description, notated in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nThe description SHOULD not be excessive in length and is not meant to provide full documentation.\nDetailed documentation SHOULD be attached as (typed) links."
       constraints:
         minLength: 1
+    - name: 'restrictDirection'
+      type: 'string'
+      description: 'Optionally restricts the direction of the group assignments for this group type.'
+    - name: 'restrictResourceType'
+      type: 'string'
+      array: true
+      description: 'Optionally restricts group assignments (of this group type) to ORD resource types.'
   customTypeDefinitions: []
   metadataRelations:
     - propertyName: 'groups'


### PR DESCRIPTION
### Added

- Added `members` assignment from a Group to ORD Resources
  - So far, ORD resources could only define their `partOfGroups` assignment, assuming they know which group (instances) they belong to
  - Sometimes not just the group taxonomy is defined externally, but also the group assignment. In this case, it is the group which knows which ORD resources are part of it (`members`), not vice versa
  - For an ORD aggregator this comes with a new challenge, as the relationship between group and its constituents can be defined from both sides
- Added `restrictDirection` to optionally restrict the direction of group assignments to either resource -> group or vice versa.
- Added `restrictResourceType` to optionally restrict group assignments to one or more ORD resource types.


@swennemers I'm least sure about `restrictDirection` if we really need this. Also we could leave out `restrictResourceType` for now. It might help with validation of correct use of taxonomy later, though.
