### PR TITLE
fix: namespace regex part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
   - Old: https://open-resource-discovery.github.io/specification
   - New: https://open-resource-discovery.org
 - $id of both Document and Configuration schemas now point to a new domain (with a proper redirect from the old location)
-- Increased minimum Node.js version to v22 LTS
+- breaking: increased minimum Node.js version to v22 LTS
+- breaking: fixed namespace part check from `^([a-z0-9-]+(?:[.][a-z0-9-]+)*)` to `^([a-z0-9]+(?:[.][a-z0-9]+)*)` from multiple OrdID/CorrelationId/ConceptId/SpecificationID regular expressions
 
 ### Fixed
 
@@ -25,13 +26,13 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 ### Removed
 
 - deleted SAP specific values from ORD Configuration:
-  - `AccessStrategy` values: `sap:oauth-client-credentials:v1`, `sap:cmp-mtls:v1`, `sap.businesshub:basic-auth:v1` but any string with pattern `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
+  - `AccessStrategy` values: `sap:oauth-client-credentials:v1`, `sap:cmp-mtls:v1`, `sap.businesshub:basic-auth:v1` but any string with pattern `^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
 
 - deleted SAP specific values from ORD Document:
-  - `policyLevel` values: `sap:base:v1`, `sap:core:v1`, `sap:dp:v1` but any string with pattern `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
-  - `ApiResource.implementationStandard` values: `sap:ord-document-api:v1`, `sap:csn-exposure:v1`, `sap:ape-api:v1`, `sap:cdi-api:v1`, `sap:delta-sharing:v1`, `sap:hana-cloud-sql:v1`, `sap.dp:data-subscription-api:v1` but any string with pattern `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
-  - `Package.policyLevel`, `ApiResource.policyLevel`, `EventResource.policyLevel`, `EntityType.policyLevel`, `DataProduct.policyLevel` values: `sap:base:v1`, `sap:core:v1`, `sap:dp:v1` but any string with pattern `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
-  - `AccessStrategy` values: `sap:oauth-client-credentials:v1`, `sap:cmp-mtls:v1`, `sap.businesshub:basic-auth:v1` but any string with pattern `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
+  - `policyLevel` values: `sap:base:v1`, `sap:core:v1`, `sap:dp:v1` but any string with pattern `^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
+  - `ApiResource.implementationStandard` values: `sap:ord-document-api:v1`, `sap:csn-exposure:v1`, `sap:ape-api:v1`, `sap:cdi-api:v1`, `sap:delta-sharing:v1`, `sap:hana-cloud-sql:v1`, `sap.dp:data-subscription-api:v1` but any string with pattern `^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
+  - `Package.policyLevel`, `ApiResource.policyLevel`, `EventResource.policyLevel`, `EntityType.policyLevel`, `DataProduct.policyLevel` values: `sap:base:v1`, `sap:core:v1`, `sap:dp:v1` but any string with pattern `^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
+  - `AccessStrategy` values: `sap:oauth-client-credentials:v1`, `sap:cmp-mtls:v1`, `sap.businesshub:basic-auth:v1` but any string with pattern `^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
 
 ## [1.12.3]
 

--- a/docs/spec-v1/index.md
+++ b/docs/spec-v1/index.md
@@ -843,7 +843,7 @@ It MUST be constructed as defined here:
 An ORD ID MUST match the following [regular expression](https://en.wikipedia.org/wiki/Regular_expression):
 
 ```regex
-^([a-z0-9-]+(?:[.][a-z0-9-]+)*):(package|consumptionBundle|product|vendor|apiResource|eventResource|capability|entityType|integrationDependency|dataProduct):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*|)$
+^([a-z0-9]+(?:[.][a-z0-9]+)*):(package|consumptionBundle|product|vendor|apiResource|eventResource|capability|entityType|integrationDependency|dataProduct):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*|)$
 ```
 
 Examples:
@@ -899,7 +899,7 @@ A Correlation ID MUST not exceed 255 characters in total.
 A Correlation ID MUST match the following [regular expression](https://en.wikipedia.org/wiki/Regular_expression):
 
 ```regex
-^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-\/]+):([a-zA-Z0-9._\-\/]+)$
+^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+):([a-zA-Z0-9._\-\/]+)$
 ```
 
 Examples (contrived):
@@ -933,7 +933,7 @@ A Concept ID MUST not exceed 255 characters in total.
 A Concept ID MUST match the following [regular expression](https://en.wikipedia.org/wiki/Regular_expression):
 
 ```regex
-^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-\/]+)$
+^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+)$
 ```
 
 Examples (contrived):
@@ -974,7 +974,7 @@ A Specification ID MUST not exceed 255 characters in total.
 A Specification ID MUST match the following [regular expression](https://en.wikipedia.org/wiki/Regular_expression):
 
 ```regex
-^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
 ```
 
 ## Version and Lifecycle

--- a/spec/v1/Configuration.schema.yaml
+++ b/spec/v1/Configuration.schema.yaml
@@ -203,7 +203,7 @@ definitions:
           Defines the authentication/authorization strategy through which the referenced ORD Documents can be accessed.
         anyOf:
           - type: string
-            pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
             description: |-
               Any valid [Specification ID](../index.md#specification-id).
               If chosen, `customDescription` SHOULD be provided.

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -139,7 +139,7 @@ properties:
       The policy level can be defined on ORD Document level, but also be overwritten on an individual package or resource level.
     anyOf:
       - type: string
-        pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+        pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
         description: |-
           Any valid [Specification ID](../index.md#specification-id).
       - const: "none"
@@ -909,7 +909,7 @@ definitions:
         type: array
         items:
           type: string
-          pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-\/]+):([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-\/]+)$
+          pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+):([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-\/]+)$
           x-association-target:
             - "#/definitions/Group/groupId"
         x-ums-reverse-relationship:
@@ -1137,7 +1137,7 @@ definitions:
         description: API Protocol including the protocol version if applicable
         anyOf:
           - type: string
-            pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
             description: |-
               Any valid [Specification ID](../index.md#specification-id).
           - const: odata-v2
@@ -1239,7 +1239,7 @@ definitions:
         anyOf:
           # More standards can be added via simple feature request and minor releases.
           - type: string
-            pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
             description: |-
               Any valid [Specification ID](../index.md#specification-id).
               If chosen, `customImplementationStandardDescription` SHOULD be provided.
@@ -1336,7 +1336,7 @@ definitions:
           type: string
           anyOf:
             - type: string
-              pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+              pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
               description: |-
                 Any valid [Specification ID](../index.md#specification-id).
             - const: data-federation
@@ -1644,7 +1644,7 @@ definitions:
 
               RECOMMENDED to use if the contract is published via ORD and has an ORD ID.
           - type: string
-            pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
             description: |-
               Any valid [Specification ID](../index.md#specification-id).
               If chosen, `customImplementationStandardDescription` SHOULD be provided.
@@ -2163,7 +2163,7 @@ definitions:
         type: string
         anyOf:
           - type: string
-            pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
             description: |-
               Any valid [Specification ID](../index.md#specification-id).
           - const: business-object
@@ -2385,7 +2385,7 @@ definitions:
         type: string
         anyOf:
           - type: string
-            pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
             description: |-
               Any valid [Specification ID](../index.md#specification-id).
           - const: openapi-v2
@@ -2546,7 +2546,7 @@ definitions:
         type: string
         anyOf:
           - type: string
-            pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
             description: |-
               Any valid [Specification ID](../index.md#specification-id).
           - const: asyncapi-v2
@@ -2685,7 +2685,7 @@ definitions:
     properties:
       ordId:
         <<: *ordId
-        pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):(capability):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+        pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):(capability):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
         examples:
           - "sap.foo.bar:capability:fieldExtensibility:v1"
 
@@ -2700,7 +2700,7 @@ definitions:
         type: string
         anyOf:
           - type: string
-            pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
             description: |-
               Any valid [Specification ID](../index.md#specification-id).
           - const: "sap.mdo:mdi-capability:v1"
@@ -2861,7 +2861,7 @@ definitions:
         type: string
         anyOf:
           - type: string
-            pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
             description: |-
               Any valid [Specification ID](../index.md#specification-id).
           - const: "sap.mdo:mdi-capability-definition:v1"
@@ -2928,7 +2928,7 @@ definitions:
     properties:
       ordId:
         <<: *ordId
-        pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):(integrationDependency):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+        pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):(integrationDependency):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
         examples:
           - "sap.foo.bar:integrationDependency:CustomerOrder:v1"
 
@@ -3012,7 +3012,7 @@ definitions:
           One situation would be where two systems each have an Integration Dependency to describe a two-sided integration from each side.
         items:
           type: string
-          pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):(integrationDependency):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+          pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):(integrationDependency):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
           x-association-target:
             - "#/definitions/IntegrationDependency/ordId"
         examples:
@@ -3125,7 +3125,7 @@ definitions:
       #     Within the context of the Integration Dependency, there can be constraints which Consumption Bundles to use.
       #   items:
       #     type: string
-      #     pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):(consumptionBundle):([a-zA-Z0-9._\-]+):(alpha|beta|v[0-9]+|)$
+      #     pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):(consumptionBundle):([a-zA-Z0-9._\-]+):(alpha|beta|v[0-9]+|)$
       #   examples:
       #     - ['sap.foo:consumptionBundle:basicAuth:v1']
 
@@ -3384,7 +3384,7 @@ definitions:
         type: string
         anyOf:
           - type: string
-            pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
             description: |-
               Any valid [Specification ID](../index.md#specification-id).
           - const: terms-of-service
@@ -3454,7 +3454,7 @@ definitions:
           See also: [WADG0001 WebAPI type extension](https://webapi-discovery.github.io/rfcs/rfc0001.html#webapiactions)
         anyOf:
           - type: string
-            pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
             description: |-
               Any valid [Specification ID](../index.md#specification-id).
           - const: api-documentation
@@ -3525,7 +3525,7 @@ definitions:
         type: string
         anyOf:
           - type: string
-            pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
             description: |-
               Any valid [Specification ID](../index.md#specification-id).
           - const: payment
@@ -3726,7 +3726,7 @@ definitions:
           Defines the authentication/authorization strategy through which the referenced `resourceDefinitions` are accessible.
         anyOf:
           - type: string
-            pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
             description: |-
               Any valid [Specification ID](../index.md#specification-id).
               If chosen, `customDescription` SHOULD be provided.
@@ -3795,7 +3795,7 @@ definitions:
           The type of credential exchange strategy.
         anyOf:
           - type: string
-            pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
             description: |-
               Any valid [Specification ID](../index.md#specification-id).
               If chosen, `customDescription` SHOULD be provided.
@@ -3886,7 +3886,7 @@ definitions:
     properties:
       groupTypeId: &groupTypeId
         type: string
-        pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-\/]+)$
+        pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+)$
         description: |-
           GroupType ID, which MUST be a valid [Concept ID](../../spec-v1/#concept-id).
         examples:
@@ -3930,7 +3930,7 @@ definitions:
     properties:
       groupId: &groupId
         type: string
-        pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-\/]+):([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-\/]+)$
+        pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+):([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-\/]+)$
         description: |-
           The Group ID consists of two [Concept IDs](../../spec-v1/#concept-id) separated by a `:`.
 
@@ -4494,7 +4494,7 @@ definitions:
     properties:
       ordId:
         <<: *ordId
-        pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):(apiResource|eventResource|capability|dataProduct):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*|)$
+        pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):(apiResource|eventResource|capability|dataProduct):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*|)$
         examples: []
 
       localId:

--- a/static/spec-v1/interfaces/ums/AbstractMetadataType/ordresource.yaml
+++ b/static/spec-v1/interfaces/ums/AbstractMetadataType/ordresource.yaml
@@ -23,7 +23,7 @@ spec:
       mandatory: true
       constraints:
         maxLength: 255
-        pattern: '^([a-z0-9-]+(?:[.][a-z0-9-]+)*):(apiResource|eventResource|capability|dataProduct):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*|)$'
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(apiResource|eventResource|capability|dataProduct):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*|)$'
     - name: 'localId'
       type: 'string'
       description: "The locally unique ID under which this resource can be looked up / resolved in the described system itself.\nUnlike the ORD ID it's not globally unique, but it may be useful to document the original ID / technical name.\n\nIt MAY also be used as the `<resourceName>` fragment in the ORD ID, IF it can fulfill the charset and length limitations within the ORD ID.\nBut since this is not always possible, no assumptions MUST be made about the local ID being the same as the `<resourceName>` fragment in the ORD ID."

--- a/static/spec-v1/interfaces/ums/MetadataType/capability.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/capability.yaml
@@ -23,7 +23,7 @@ spec:
       mandatory: true
       constraints:
         maxLength: 255
-        pattern: '^([a-z0-9-]+(?:[.][a-z0-9-]+)*):(capability):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(capability):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
     - name: 'localId'
       type: 'string'
       description: "The locally unique ID under which this resource can be looked up / resolved in the described system itself.\nUnlike the ORD ID it's not globally unique, but it may be useful to document the original ID / technical name.\n\nIt MAY also be used as the `<resourceName>` fragment in the ORD ID, IF it can fulfill the charset and length limitations within the ORD ID.\nBut since this is not always possible, no assumptions MUST be made about the local ID being the same as the `<resourceName>` fragment in the ORD ID."

--- a/static/spec-v1/interfaces/ums/MetadataType/group.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/group.yaml
@@ -22,13 +22,13 @@ spec:
       description: "The Group ID consists of two [Concept IDs](../../spec-v1/#concept-id) separated by a `:`.\n\nThe first two fragments MUST be equal to the used Group Type ID (`groupTypeId`).\nThe last two fragments MUST be a valid [Concept ID](../../spec-v1/#concept-id), indicating the group instance assignment.\n\nThe ID concept is a bit unusual, but it ensures globally unique and conflict free group assignments."
       mandatory: true
       constraints:
-        pattern: '^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-\/]+):([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-\/]+)$'
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+):([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-\/]+)$'
     - name: 'groupTypeId_ID'
       type: 'guid'
       description: "Group Type ID.\n\nMUST match with the first two fragments of the own `groupId`."
       mandatory: true
       constraints:
-        pattern: '^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-\/]+)$'
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+)$'
     - name: 'title'
       type: 'string'
       description: 'Human readable title of the group assignment (for UI).'

--- a/static/spec-v1/interfaces/ums/MetadataType/grouptype.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/grouptype.yaml
@@ -22,7 +22,7 @@ spec:
       description: 'GroupType ID, which MUST be a valid [Concept ID](../../spec-v1/#concept-id).'
       mandatory: true
       constraints:
-        pattern: '^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-\/]+)$'
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+)$'
     - name: 'title'
       type: 'string'
       description: 'Human readable title of the group type.'

--- a/static/spec-v1/interfaces/ums/MetadataType/integrationdependency.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/integrationdependency.yaml
@@ -23,7 +23,7 @@ spec:
       mandatory: true
       constraints:
         maxLength: 255
-        pattern: '^([a-z0-9-]+(?:[.][a-z0-9-]+)*):(integrationDependency):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(integrationDependency):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
     - name: 'localId'
       type: 'string'
       description: "The locally unique ID under which this resource can be looked up / resolved in the described system itself.\nUnlike the ORD ID it's not globally unique, but it may be useful to document the original ID / technical name.\n\nIt MAY also be used as the `<resourceName>` fragment in the ORD ID, IF it can fulfill the charset and length limitations within the ORD ID.\nBut since this is not always possible, no assumptions MUST be made about the local ID being the same as the `<resourceName>` fragment in the ORD ID."


### PR DESCRIPTION
There were inconsistent regular expressions for checking the namespace part of an OrdID/CorrelationID/ConceptID/SpecificationID.

This PR aims for consistency everywhere: No `-` allowed in namespace [fragments](https://open-resource-discovery.org/spec-v1#structure-of-namespaces) (vendor, application service, sub-context ).

E.g. following values would be forbidden from now on by the fix:
sap-.foo:base:v1
sap.foo-:base:v1
sap.foo.bar-:base:v1