### PR TITLE
Release ORD v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+## [1.13.0]
+
 ### Added
 
 - Added `system-type` perspective to describe static metadata that is not version dependent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 - Added `system-type` perspective to describe static metadata that is not version dependent.
 - Added `data-loading` and `data-loading-error` as new `lifecycleStatus` for Data Products
-  - This statuses indicates that the Data Product metadata is ready, and data loading is in progress.
+  - These statuses indicate that the Data Product metadata is ready, and data loading is in progress.
 - Added optional `visibility` to API Resource Definition, Event Resource Definition and Capability Definition
   - By default the definitions have the same visibility as the resource they belong to
   - The visibility of a resource definition MUST be lower (more restrictive) than the visibility of the resource it describes.

--- a/docs/spec-v1/index.md
+++ b/docs/spec-v1/index.md
@@ -3,7 +3,7 @@ sidebar_position: 0
 title: ORD Specification
 ---
 
-# Open Resource Discovery Specification 1.12
+# Open Resource Discovery Specification 1.13
 
 ## Notational Conventions
 

--- a/examples/documents/document-1.json
+++ b/examples/documents/document-1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://open-resource-discovery.org/spec-v1/interfaces/Document.schema.json",
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.13",
   "description": "Example based on ORD Reference App",
   "policyLevels": ["sap:core:v1"],
   "describedSystemType": {

--- a/examples/documents/document-data-product.json
+++ b/examples/documents/document-data-product.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://open-resource-discovery.org/spec-v1/interfaces/Document.schema.json",
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.13",
   "policyLevels": ["sap:core:v1"],
   "products": [
     {

--- a/examples/documents/document-entity-types.json
+++ b/examples/documents/document-entity-types.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://open-resource-discovery.org/spec-v1/interfaces/Document.schema.json",
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.13",
   "description": "Example for entity types as they will be exposed by ODM",
   "policyLevels": ["sap:core:v1"],
   "packages": [

--- a/examples/documents/document-integration-dependencies.jsonc
+++ b/examples/documents/document-integration-dependencies.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "https://open-resource-discovery.org/spec-v1/interfaces/Document.schema.json",
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.13",
   "integrationDependencies": [
     // This is an example for a simple Integration Dependency
     // that only expresses that only declares that some events are needed together

--- a/examples/documents/document-poc.jsonc
+++ b/examples/documents/document-poc.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "https://open-resource-discovery.org/spec-v1/interfaces/Document.schema.json",
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.13",
   // This document demonstrates that we can also write .jsonc (JSON with Comments) examples.
   // JSONC can be helpful for PoCs where we start with writing example ORD documents with additional explanations.
   // Please note that this is not supported for a real productive implementation, where only plain JSON is allowed.

--- a/examples/documents/document-special-protocols.json
+++ b/examples/documents/document-special-protocols.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://open-resource-discovery.org/spec-v1/interfaces/Document.schema.json",
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.13",
   "description": "This ORD Document example contains more special examples, like custom SAP protocols",
   "policyLevels": ["sap:core:v1"],
   "consumptionBundles": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-resource-discovery/specification",
-  "version": "1.12.4",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-resource-discovery/specification",
-      "version": "1.12.4",
+      "version": "1.13.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@docusaurus/core": "3.9.2",
@@ -18,7 +18,7 @@
         "@open-resource-discovery/spec-toolkit": "0.5.0",
         "@types/fs-extra": "11.0.4",
         "clsx": "2.1.1",
-        "fs-extra": "11.3.2",
+        "fs-extra": "11.3.3",
         "lefthook": "2.0.12",
         "prism-react-renderer": "2.4.1",
         "react": "18.3.1",
@@ -5284,6 +5284,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@open-resource-discovery/spec-toolkit/node_modules/fs-extra": {
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
+      "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -11219,9 +11234,9 @@
       "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
-      "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
+      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/package",
   "name": "@open-resource-discovery/specification",
-  "version": "1.12.4",
+  "version": "1.13.0",
   "description": "Open Resource Discovery (ORD) Specification",
   "author": "SAP SE",
   "license": "Apache-2.0",
@@ -44,7 +44,7 @@
     "@open-resource-discovery/spec-toolkit": "0.5.0",
     "@types/fs-extra": "11.0.4",
     "clsx": "2.1.1",
-    "fs-extra": "11.3.2",
+    "fs-extra": "11.3.3",
     "lefthook": "2.0.12",
     "prism-react-renderer": "2.4.1",
     "react": "18.3.1",

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -53,8 +53,9 @@ properties:
       - "1.10"
       - "1.11"
       - "1.12"
+      - "1.13"
     examples:
-      - "1.12"
+      - "1.13"
 
   description:
     type: string

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -914,7 +914,7 @@ definitions:
         type: array
         items:
           type: string
-          pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+):([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-\/]+)$
+          pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+):([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+)$
           x-association-target:
             - "#/definitions/Group/groupId"
         x-ums-reverse-relationship:
@@ -3947,7 +3947,7 @@ definitions:
         type: array
         items:
           type: string
-          pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-\/]+)$
+          pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+)$
           x-association-target:
             - "#/definitions/GroupType/groupTypeId"
         x-ums-reverse-relationship:
@@ -3988,7 +3988,7 @@ definitions:
     properties:
       groupId: &groupId
         type: string
-        pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+):([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-\/]+)$
+        pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+):([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+)$
         description: |-
           The Group ID consists of two [Concept IDs](../../spec-v1/#concept-id) separated by a `:`.
 

--- a/spec/v1/DocumentAPI.oas3.yaml
+++ b/spec/v1/DocumentAPI.oas3.yaml
@@ -4,7 +4,7 @@ info:
     Open Resource Discovery (ORD) is a protocol that standardizes how applications and services publish and discover their exposed resources such as APIs and Events.
 
     This API is an implementation of the [ORD Provider API](../index.md#ord-provider-api).
-  version: 1.9.0
+  version: 1.13.0
   title: Open Resource Discovery Document API
   license:
     name: Apache 2.0

--- a/src/generated/spec/v1/types/Document.ts
+++ b/src/generated/spec/v1/types/Document.ts
@@ -35,7 +35,8 @@ export interface OrdDocument {
     | "1.9"
     | "1.10"
     | "1.11"
-    | "1.12";
+    | "1.12"
+    | "1.13";
   /**
    * Optional description of the ORD document itself.
    * Please note that this information is NOT further processed or considered by an ORD aggregator.

--- a/static/spec-v1/interfaces/DocumentAPI.oas3.yaml
+++ b/static/spec-v1/interfaces/DocumentAPI.oas3.yaml
@@ -4,7 +4,7 @@ info:
     Open Resource Discovery (ORD) is a protocol that standardizes how applications and services publish and discover their exposed resources such as APIs and Events.
 
     This API is an implementation of the [ORD Provider API](../index.md#ord-provider-api).
-  version: 1.9.0
+  version: 1.13.0
   title: Open Resource Discovery Document API
   license:
     name: Apache 2.0

--- a/static/spec-v1/interfaces/ums/MetadataType/group.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/group.yaml
@@ -22,7 +22,7 @@ spec:
       description: "The Group ID consists of two [Concept IDs](../../spec-v1/#concept-id) separated by a `:`.\n\nThe first two fragments MUST be equal to the used Group Type ID (`groupTypeId`).\nThe last two fragments MUST be a valid [Concept ID](../../spec-v1/#concept-id), indicating the group instance assignment.\n\nThe ID concept is a bit unusual, but it ensures globally unique and conflict-free group assignments."
       mandatory: true
       constraints:
-        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+):([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-\/]+)$'
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+):([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+)$'
     - name: 'groupTypeId_ID'
       type: 'guid'
       description: "Group Type ID.\n\nMUST match with the first two fragments of the own `groupId`."


### PR DESCRIPTION

## [1.13.0]

### Added

- Added `system-type` perspective to describe static metadata that is not version dependent.
- Added `data-loading` and `data-loading-error` as new `lifecycleStatus` for Data Products
  - This statuses indicates that the Data Product metadata is ready, and data loading is in progress.
- Added optional `visibility` to API Resource Definition, Event Resource Definition and Capability Definition
  - By default the definitions have the same visibility as the resource they belong to
  - The visibility of a resource definition MUST be lower (more restrictive) than the visibility of the resource it describes.
    E.g. a public resource can declare to have some resource definitions that are internal while others are public. An internal resource can't set a resource definition to be public.
- Added expressing hierarchical taxonomies and graph relationships for both group types and group instances
  - Added `partOfGroupTypes` to Group Types, allowing group types to be hierarchically organized
  - Added `partOfGroups` to Groups, allowing group instances to be hierarchically organized

### Changed

- The public ORD page changed its domain name:
  - Old: https://open-resource-discovery.github.io/specification
  - New: https://open-resource-discovery.org
- $id of both Document and Configuration schemas now point to a new domain (with a proper redirect from the old location)
- breaking: increased minimum Node.js version to v22 LTS
- breaking: fixed namespace part check from `^([a-z0-9-]+(?:[.][a-z0-9-]+)*)` to `^([a-z0-9]+(?:[.][a-z0-9]+)*)` from multiple OrdID/CorrelationId/ConceptId/SpecificationID regular expressions

### Fixed

- make AccessStrategy from ORD Configuration consistent with AccessStrategy from ORD Document (both should use `anyOf` for the allowed values)
- Breaking: The `minSystemVersion` was not properly validated against semver, although the version it refers to (`describedSystemVersion.version`) is a mandatory semver.
  - Fixed the regex to properly validate against [Semantic Versioning 2.0.0](https://semver.org/) standard.
  - Added to documentation that this is an association to `SystemVersion.version`.
  - Introducing this as bugfix, as this property was presumed to be semver. This change just adds validation and explicit mentioning to ensure it.
  - If `minSystemVersion` is not a SemVer, it would be unclear how to do the version comparison anyway.

### Removed

- deleted SAP specific values from ORD Configuration:
  - `AccessStrategy` values: `sap:oauth-client-credentials:v1`, `sap:cmp-mtls:v1`, `sap.businesshub:basic-auth:v1` but any string with pattern `^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed

- deleted SAP specific values from ORD Document:
  - `policyLevel` values: `sap:base:v1`, `sap:core:v1`, `sap:dp:v1` but any string with pattern `^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
  - `ApiResource.implementationStandard` values: `sap:ord-document-api:v1`, `sap:csn-exposure:v1`, `sap:ape-api:v1`, `sap:cdi-api:v1`, `sap:delta-sharing:v1`, `sap:hana-cloud-sql:v1`, `sap.dp:data-subscription-api:v1` but any string with pattern `^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
  - `Package.policyLevel`, `ApiResource.policyLevel`, `EventResource.policyLevel`, `EntityType.policyLevel`, `DataProduct.policyLevel` values: `sap:base:v1`, `sap:core:v1`, `sap:dp:v1` but any string with pattern `^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
  - `AccessStrategy` values: `sap:oauth-client-credentials:v1`, `sap:cmp-mtls:v1`, `sap.businesshub:basic-auth:v1` but any string with pattern `^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\\-]+):(v0|v[1-9][0-9]*)$` is allowed therefore using these values is still allowed
