### PR TITLE
preserve `x-ums-type` property in the configuration and document schema

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,4 @@ These examples demonstrate ORD features but require customization before use. Sp
 All files in this folder will be used for example documentation and will also be validated.
 
 All ORD Documents MUST start with `document-` and all ORD Configs with `configuration-`.
-The file extension must be `.json`, so they are considered for documentation and validation.
-
-Files with `.jsonc` extension can be created for PoC / prototyping purposes, but they will essentially be ignored.
+The file extension must be `.json` or `.jsonc`, so they are considered for documentation and validation.

--- a/examples/documents/document-poc.jsonc
+++ b/examples/documents/document-poc.jsonc
@@ -5,5 +5,4 @@
   // JSONC can be helpful for PoCs where we start with writing example ORD documents with additional explanations.
   // Please note that this is not supported for a real productive implementation, where only plain JSON is allowed.
   // The API Metadata Validator will also not support JSONC, but we'll have VSCode internal code intelligence and schema validation.
-  // .jsonc documents in this folder will be ignored when validating examples files.
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@docusaurus/theme-mermaid": "3.9.2",
         "@easyops-cn/docusaurus-search-local": "0.52.2",
         "@mdx-js/react": "3.1.1",
-        "@open-resource-discovery/spec-toolkit": "0.5.0",
+        "@open-resource-discovery/spec-toolkit": "0.6.0",
         "@types/fs-extra": "11.0.4",
         "clsx": "2.1.1",
         "fs-extra": "11.3.3",
@@ -251,7 +251,6 @@
       "integrity": "sha512-G9I2atg1ShtFp0t7zwleP6aPS4DcZvsV4uoQOripp16aR6VJzbEnKFPLW4OFXzX7avgZSpYeBAS+Zx4FOgmpPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.41.0",
         "@algolia/requester-browser-xhr": "5.41.0",
@@ -429,7 +428,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2406,7 +2404,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2430,7 +2427,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2545,7 +2541,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2983,7 +2978,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3906,7 +3900,6 @@
       "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/logger": "3.9.2",
@@ -4186,7 +4179,6 @@
       "integrity": "sha512-6c4DAbR6n6nPbnZhY2V3tzpnKnGL+6aOsLvFL26VRqhlczli9eWG0VDUNoCQEPnGwDMhPS42UhSAnz5pThm5Ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@docusaurus/mdx-loader": "3.9.2",
         "@docusaurus/module-type-aliases": "3.9.2",
@@ -4906,7 +4898,6 @@
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -5249,18 +5240,19 @@
       }
     },
     "node_modules/@open-resource-discovery/spec-toolkit": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@open-resource-discovery/spec-toolkit/-/spec-toolkit-0.5.0.tgz",
-      "integrity": "sha512-yZ9zaO0Sr4pXq9QQdKCpm0CWQE1ppgFTHL+rcMCGgxnA3La7kepKGC9J6celBLuRduJEankHT9sdw4rLVbamfw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@open-resource-discovery/spec-toolkit/-/spec-toolkit-0.6.0.tgz",
+      "integrity": "sha512-HeUkky8nRfcMBu0ZEVDJkP31T0tubucF/kdm3dNgNumzl2gCfKqjjkBCdJv3WKN/LR5dIi6AvfrsTiaHqXOMsQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "8.17.1",
         "ajv-formats": "3.0.1",
         "commander": "14.0.2",
+        "comment-json": "4.5.1",
         "exceljs": "4.4.0",
         "fast-glob": "3.3.3",
-        "fs-extra": "11.3.2",
+        "fs-extra": "11.3.3",
         "gfm-escape": "0.2.0",
         "js-yaml": "4.1.1",
         "json-schema-to-typescript": "15.0.4",
@@ -5284,21 +5276,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/@open-resource-discovery/spec-toolkit/node_modules/fs-extra": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
-      "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -5595,7 +5572,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -6322,7 +6298,6 @@
       "integrity": "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -6364,7 +6339,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -6774,7 +6748,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6867,7 +6840,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6916,7 +6888,6 @@
       "integrity": "sha512-9E4b3rJmYbBkn7e3aAPt1as+VVnRhsR4qwRRgOzpeyz4PAOuwKh0HI4AN6mTrqK0S0M9fCCSTOUnuJ8gPY/tvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.7.0",
         "@algolia/client-abtesting": "5.41.0",
@@ -7163,6 +7134,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/array-timsort": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7590,7 +7568,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -7980,7 +7957,6 @@
       "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.0.3",
         "@chevrotain/gast": "11.0.3",
@@ -8249,6 +8225,21 @@
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/comment-json": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.5.1.tgz",
+      "integrity": "sha512-taEtr3ozUmOB7it68Jll7s0Pwm+aoiHyXKrEC8SEodL4rNpdfDLqa7PfBlrgFoCNNdR8ImL+muti5IGvktJAAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-timsort": "^1.0.3",
+        "core-util-is": "^1.0.3",
+        "esprima": "^4.0.1"
+      },
       "engines": {
         "node": ">= 6"
       }
@@ -8812,7 +8803,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9149,7 +9139,6 @@
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -9594,7 +9583,6 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11011,7 +10999,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -16573,7 +16560,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -17233,7 +17219,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -18185,7 +18170,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -19154,7 +19138,6 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -19168,7 +19151,6 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -19230,7 +19212,6 @@
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -19261,7 +19242,6 @@
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -21287,7 +21267,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -21470,8 +21449,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tslog": {
       "version": "4.9.3",
@@ -22037,7 +22015,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -22334,7 +22311,6 @@
       "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -23073,7 +23049,6 @@
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@docusaurus/theme-mermaid": "3.9.2",
     "@easyops-cn/docusaurus-search-local": "0.52.2",
     "@mdx-js/react": "3.1.1",
-    "@open-resource-discovery/spec-toolkit": "0.5.0",
+    "@open-resource-discovery/spec-toolkit": "0.6.0",
     "@types/fs-extra": "11.0.4",
     "clsx": "2.1.1",
     "fs-extra": "11.3.3",

--- a/spec-toolkit.config.json
+++ b/spec-toolkit.config.json
@@ -33,7 +33,8 @@
       "packageName": "./node_modules/@open-resource-discovery/spec-toolkit/dist/plugin/ums/index.js",
       "options": {
         "metadataPath": "/sap/core/ucl/metadata/ord/v1",
-        "overrides": ["./spec/v1/Document.ums.yaml"]
+        "overrides": ["./spec/v1/Document.ums.yaml"],
+        "preservedPluginSpecificXProperties": ["x-ums-type"]
       }
     },
     {


### PR DESCRIPTION
update spec-toolkit to [v.0.6.0](https://github.com/open-resource-discovery/spec-toolkit/releases/tag/v0.6.0) and preserve x-ums-type property in the final configuration and document schema