### PR TITLE
Use light-theme by default (fixed) but keep dark index page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -104,7 +104,7 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       colorMode: {
-        defaultMode: "dark",
+        defaultMode: "light",
         disableSwitch: false,
         respectPrefersColorScheme: false,
       },
@@ -245,15 +245,9 @@ const config = {
             <div class="neonephos-logos">
               <a href="https://neonephos.org/" target="_blank" rel="noopener noreferrer" class="neonephos-link">
                 <img
-                  src="${baseUrl + "img/ord-footer-neonephos.svg"}"
+                  src="${baseUrl + "img/ord-footer-neonephos-light.svg"}"
                   alt="Neonephos Logo"
                   class="neonephos-logo neonephos-logo--dark"
-                />
-                <img
-                  src="${baseUrl + "img/ord-footer-neonephos-light.svg"}"
-                  alt=""
-                  aria-hidden="true"
-                  class="neonephos-logo neonephos-logo--light"
                 />
               </a>
             </div>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -17,3 +17,66 @@
   white-space: normal;
   word-wrap: break-word;
 }
+
+/* Style index page to have dark appearance while staying in light mode */
+#__docusaurus:has(.ord-home-flag) {
+  --lp-c-bg: #1b1b1d;
+  --lp-c-bg-alt: #161618;
+  --lp-c-bg-elv: #202127;
+  --lp-c-bg-soft: #202127;
+  --lp-c-border: #3c3f44;
+  --lp-c-divider: #2e2e32;
+  --lp-c-text-1: #dfdfd6;
+  --lp-c-text-2: #98989f;
+  --lp-c-text-3: #6a6a71;
+  --c-text-dim: #6a6a71;
+  background-color: #1b1b1d;
+}
+
+.lp-home {
+  background: #1b1b1d;
+  color: #dfdfd6;
+}
+
+.lp-home .action {
+  background-color: #242526;
+  color: #ffffff;
+}
+
+.lp-home .action:hover {
+  background-color: #2e2e30;
+}
+
+.lp-home a {
+  color: #64b5f6;
+}
+
+.lp-home a:hover {
+  color: #81c5ff;
+}
+
+/* Always use light grey footer regardless of page theme */
+.footer {
+  --ifm-footer-background-color: #f5f5f5;
+  background-color: var(--ifm-footer-background-color);
+  --ifm-footer-color: #0a0a0a;
+  --lp-c-text-2: #454545;
+  color: var(--ifm-footer-color);
+}
+
+.footer a {
+  color: #0066cc;
+}
+
+.footer a:hover {
+  color: #0052a3;
+}
+
+/* Always show the dark NeoNephos logo since footer background is always light grey */
+.neonephos-logo--light {
+  display: none !important;
+}
+
+.neonephos-logo--dark {
+  display: inline !important;
+}

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -102,10 +102,10 @@
   display: inline;
 }
 html[data-theme="light"] .neonephos-logo--dark {
-  display: none;
+  display: inline;
 }
 html[data-theme="light"] .neonephos-logo--light {
-  display: inline;
+  display: none;
 }
 .footer-legal-links {
   display: flex;
@@ -220,7 +220,7 @@ html[data-theme="light"] .neonephos-logo--light {
   max-width: 600px;
 }
 .lp-home .definition {
-  color: var(--c-text-dim);
+  color: #a0a0a0;
   font-size: 14px;
   line-height: 22px;
   margin: 24px auto 0;
@@ -624,13 +624,12 @@ html[data-theme="light"] .lp-home .actions .action:active {
   box-shadow: none;
 }
 html[data-theme="light"] .footer-funding__text p {
-  color: #b0b5ba;
+  color: #646464;
   margin: 0;
   font-size: 12px;
   text-align: left;
 }
 html[data-theme="light"] .footer-funding__text strong {
-  color: #b0b5ba;
   font-weight: 600;
 }
 


### PR DESCRIPTION
The dark theme as default doesn't work so well for a spec page, where there is so much text and diagrams that presume lighter background. But I like how the dark index page looks. 

I tried to have the index page dark, light-theme is now the default for the rest of the page.