### PR TITLE
Allow integration dependencies to also refer to capabilitites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+### Added
+
+- Added `CapabilityIntegrationAspect` definition to support capability dependencies in integration aspects
+  - Capabilities can now be referenced as integration dependencies alongside API and Event Resources
+  - Includes `ordId` and `minVersion` properties for capability integration aspects
+
+### Fixed
+
+- Fixed typo in `IntegrationAspect` schema: renamed `capabilitites` to `capabilities`
+
 ## [1.14.1]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,6 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
   - Capabilities can now be referenced as integration dependencies alongside API and Event Resources
   - Includes `ordId` and `minVersion` properties for capability integration aspects
 
-### Fixed
-
-- Fixed typo in `IntegrationAspect` schema: renamed `capabilitites` to `capabilities`
-
 ## [1.14.1]
 
 ### Changed

--- a/examples/documents/document-integration-dependencies.jsonc
+++ b/examples/documents/document-integration-dependencies.jsonc
@@ -131,6 +131,17 @@
             },
           ],
         },
+        {
+          "title": "Field Extensibility Support",
+          "description": "Requires field extensibility capability for custom field integration",
+          "mandatory": true,
+          "capabilities": [
+            {
+              "ordId": "sap.s4:capability:fieldExtensibility:v1",
+              "minVersion": "2.0.0"
+            }
+          ]
+        },
       ],
     },
   ],

--- a/examples/documents/document-integration-dependencies.jsonc
+++ b/examples/documents/document-integration-dependencies.jsonc
@@ -131,17 +131,6 @@
             },
           ],
         },
-        {
-          "title": "Field Extensibility Support",
-          "description": "Requires field extensibility capability for custom field integration",
-          "mandatory": true,
-          "capabilities": [
-            {
-              "ordId": "sap.s4:capability:fieldExtensibility:v1",
-              "minVersion": "2.0.0"
-            }
-          ]
-        },
       ],
     },
   ],

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -3396,7 +3396,12 @@ definitions:
         items:
           $ref: "#/definitions/EventResourceIntegrationAspect"
 
-      # NOTE: A reference to Capabilities could also make sense.
+      capabilities:
+        type: array
+        description: |-
+          List of Capability Dependencies.
+        items:
+          $ref: "#/definitions/CapabilityIntegrationAspect"
 
     additionalProperties: false
     required:
@@ -3521,6 +3526,8 @@ definitions:
     required:
       - eventType
 
+  ############################################################################################################
+
   ApiResourceIntegrationAspectSubset:
     type: object
     title: API Resource Integration Aspect Subset
@@ -3546,6 +3553,31 @@ definitions:
     additionalProperties: false
     required:
       - operationId
+
+  ############################################################################################################
+
+  CapabilityIntegrationAspect:
+    type: object
+    title: Capability Integration Aspect
+    x-introduced-in-version: "1.15.0"
+    x-ums-type: "custom"
+    description: |-
+      Capability related integration aspect
+    properties:
+      ordId:
+        <<: *ordId
+        pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):(capability):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+        examples:
+          - "sap.foo.bar:capability:fieldExtensibility:v1"
+
+      minVersion:
+        <<: *minVersion
+
+    additionalProperties: false
+    required:
+      - ordId
+
+  ############################################################################################################
 
   Vendor:
     type: object

--- a/src/generated/spec/v1/types/Document.ts
+++ b/src/generated/spec/v1/types/Document.ts
@@ -3163,6 +3163,10 @@ export interface Aspect {
    * List of Event Resource Dependencies.
    */
   eventResources?: EventResourceIntegrationAspect[];
+  /**
+   * List of Capability Dependencies.
+   */
+  capabilities?: CapabilityIntegrationAspect[];
 }
 /**
  * API resource related integration aspect
@@ -3242,6 +3246,22 @@ export interface EventResourceIntegrationAspectSubset {
    * E.g. for CloudEvents, the [type](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type) can be used.
    */
   eventType: string;
+}
+/**
+ * Capability related integration aspect
+ */
+export interface CapabilityIntegrationAspect {
+  /**
+   * The ORD ID is a stable, globally unique ID for ORD resources or taxonomy.
+   *
+   * It MUST be a valid [ORD ID](../index.md#ord-id) of the appropriate ORD type.
+   */
+  ordId: string;
+  /**
+   * Minimum version of the references resource that the integration requires.
+   *
+   */
+  minVersion?: string;
 }
 /**
  * The vendor of a product or a package, usually a corporation or a customer / user.

--- a/static/spec-v1/interfaces/ums/MetadataType/integrationdependency.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/integrationdependency.yaml
@@ -148,6 +148,11 @@ spec:
           customTypeName: 'EventResourceIntegrationAspect'
           array: true
           description: 'List of Event Resource Dependencies.'
+        - name: 'capabilities'
+          type: 'custom'
+          customTypeName: 'CapabilityIntegrationAspect'
+          array: true
+          description: 'List of Capability Dependencies.'
     - name: 'ApiResourceIntegrationAspect'
       metadataProperties:
         - name: 'ordId'
@@ -202,6 +207,20 @@ spec:
           type: 'string'
           description: "The type ID of the individual event or message.\n\nThis MUST be an ID that is understood by the used protocol and resource definition format.\nE.g. for CloudEvents, the [type](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type) can be used."
           mandatory: true
+    - name: 'CapabilityIntegrationAspect'
+      metadataProperties:
+        - name: 'ordId'
+          type: 'string'
+          description: "The ORD ID is a stable, globally unique ID for ORD resources or taxonomy.\n\nIt MUST be a valid [ORD ID](../index.md#ord-id) of the appropriate ORD type."
+          mandatory: true
+          constraints:
+            maxLength: 255
+            pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(capability):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
+        - name: 'minVersion'
+          type: 'string'
+          description: "Minimum version of the references resource that the integration requires.\n"
+          constraints:
+            pattern: '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
     - name: 'Link'
       metadataProperties:
         - name: 'title'


### PR DESCRIPTION
In case we use capabilitites to cover for agent skills, this would be needed. But I think it's generally sensible / useful. We already had an old TODO in the schema that this would make sense to add, too. 

### Added

- Added `CapabilityIntegrationAspect` definition to support capability dependencies in integration aspects
  - Capabilities can now be referenced as integration dependencies alongside API and Event Resources
  - Includes `ordId` and `minVersion` properties for capability integration aspects
