### PR TITLE
Add entityTypes for subset of dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+### Added
+
+- Added `entityTypes` property to `ApiResourceIntegrationAspectSubset` and `EventResourceIntegrationAspectSubset`
+  - This allows narrowing down integration dependencies by a list of entity type ORD IDs
+  - Can be used alone or in combination with `operationId` (for APIs) or `eventType` (for Events)
+  - When both are provided, they form an AND condition that further narrows the scope
+  - Made `operationId` and `eventType` optional, as `entityTypes` can now be used independently
+
 ## [1.14.1]
 
 ### Changed

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -3506,6 +3506,8 @@ definitions:
 
       For events, this could be a list of the events that need to be subscribed in order to make the integration work.
       This information helps to narrow down what is really necessary and can help optimize the integration, e.g. by only publishing the events that are really needed.
+
+      The subset can be defined by `eventType`, `entityTypes`, or both. When both are provided, they form an AND condition that further narrows down the scope.
     properties:
       eventType:
         type: string
@@ -3517,9 +3519,22 @@ definitions:
         examples:
           - "sap.cic.Order.OrderTransferred.v1"
 
+      entityTypes:
+        type: array
+        description: |-
+          List of entity type ORD IDs that narrow down the scope of the integration dependency.
+
+          When provided together with `eventType`, both conditions must be satisfied (AND condition).
+        items:
+          type: string
+          pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):(entityType):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+          maxLength: 255
+          x-association-target:
+            - "#/definitions/EntityType/ordId"
+        examples:
+          - ["sap.odm:entityType:BusinessPartner:v1", "sap.odm:entityType:Order:v1"]
+
     additionalProperties: false
-    required:
-      - eventType
 
   ApiResourceIntegrationAspectSubset:
     type: object
@@ -3531,6 +3546,8 @@ definitions:
 
       For APIs, this is a list of the operations or tools that need to be available in order to make the integration work.
       This information helps to narrow down what is really necessary and can help optimize the integration.
+
+      The subset can be defined by `operationId`, `entityTypes`, or both. When both are provided, they form an AND condition that further narrows down the scope.
     properties:
       operationId:
         type: string
@@ -3543,9 +3560,22 @@ definitions:
           - "getOrderById"
           - "createCustomer"
 
+      entityTypes:
+        type: array
+        description: |-
+          List of entity type ORD IDs that narrow down the scope of the integration dependency.
+
+          When provided together with `operationId`, both conditions must be satisfied (AND condition).
+        items:
+          type: string
+          pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):(entityType):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+          maxLength: 255
+          x-association-target:
+            - "#/definitions/EntityType/ordId"
+        examples:
+          - ["sap.odm:entityType:BusinessPartner:v1", "sap.odm:entityType:Order:v1"]
+
     additionalProperties: false
-    required:
-      - operationId
 
   Vendor:
     type: object

--- a/src/generated/spec/v1/types/Document.ts
+++ b/src/generated/spec/v1/types/Document.ts
@@ -3189,6 +3189,8 @@ export interface ApiResourceIntegrationAspect {
  *
  * For APIs, this is a list of the operations or tools that need to be available in order to make the integration work.
  * This information helps to narrow down what is really necessary and can help optimize the integration.
+ *
+ * The subset can be defined by `operationId`, `entityTypes`, or both. When both are provided, they form an AND condition that further narrows down the scope.
  */
 export interface APIResourceIntegrationAspectSubset {
   /**
@@ -3197,7 +3199,13 @@ export interface APIResourceIntegrationAspectSubset {
    * This MUST be an ID that is understood by the used protocol and resource definition format.
    * E.g. for OpenAPI this is the `operationId`, for MCP this is the tool `name`.
    */
-  operationId: string;
+  operationId?: string;
+  /**
+   * List of entity type ORD IDs that narrow down the scope of the integration dependency.
+   *
+   * When provided together with `operationId`, both conditions must be satisfied (AND condition).
+   */
+  entityTypes?: string[];
 }
 /**
  * Event resource related integration aspect
@@ -3233,6 +3241,8 @@ export interface EventResourceIntegrationAspect {
  *
  * For events, this could be a list of the events that need to be subscribed in order to make the integration work.
  * This information helps to narrow down what is really necessary and can help optimize the integration, e.g. by only publishing the events that are really needed.
+ *
+ * The subset can be defined by `eventType`, `entityTypes`, or both. When both are provided, they form an AND condition that further narrows down the scope.
  */
 export interface EventResourceIntegrationAspectSubset {
   /**
@@ -3241,7 +3251,13 @@ export interface EventResourceIntegrationAspectSubset {
    * This MUST be an ID that is understood by the used protocol and resource definition format.
    * E.g. for CloudEvents, the [type](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type) can be used.
    */
-  eventType: string;
+  eventType?: string;
+  /**
+   * List of entity type ORD IDs that narrow down the scope of the integration dependency.
+   *
+   * When provided together with `eventType`, both conditions must be satisfied (AND condition).
+   */
+  entityTypes?: string[];
 }
 /**
  * The vendor of a product or a package, usually a corporation or a customer / user.

--- a/static/spec-v1/interfaces/ums/MetadataType/integrationdependency.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/integrationdependency.yaml
@@ -172,7 +172,10 @@ spec:
         - name: 'operationId'
           type: 'string'
           description: "The ID of the individual API operation or tool.\n\nThis MUST be an ID that is understood by the used protocol and resource definition format.\nE.g. for OpenAPI this is the `operationId`, for MCP this is the tool `name`."
-          mandatory: true
+        - name: 'entityTypes'
+          type: 'string'
+          array: true
+          description: "List of entity type ORD IDs that narrow down the scope of the integration dependency.\n\nWhen provided together with `operationId`, both conditions must be satisfied (AND condition)."
     - name: 'EventResourceIntegrationAspect'
       metadataProperties:
         - name: 'ordId'
@@ -201,7 +204,10 @@ spec:
         - name: 'eventType'
           type: 'string'
           description: "The type ID of the individual event or message.\n\nThis MUST be an ID that is understood by the used protocol and resource definition format.\nE.g. for CloudEvents, the [type](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type) can be used."
-          mandatory: true
+        - name: 'entityTypes'
+          type: 'string'
+          array: true
+          description: "List of entity type ORD IDs that narrow down the scope of the integration dependency.\n\nWhen provided together with `eventType`, both conditions must be satisfied (AND condition)."
     - name: 'Link'
       metadataProperties:
         - name: 'title'


### PR DESCRIPTION
Not sure about this, I just wanted to put it up as a draft PR for discussion. 
FYI, @swennemers 

### Added

- Added `entityTypes` property to `ApiResourceIntegrationAspectSubset` and `EventResourceIntegrationAspectSubset`
  - This allows narrowing down integration dependencies by a list of entity type ORD IDs
  - Can be used alone or in combination with `operationId` (for APIs) or `eventType` (for Events)
  - When both are provided, they form an AND condition that further narrows the scope
  - Made `operationId` and `eventType` optional, as `entityTypes` can now be used independently
