### PR TITLE
Add missing relations with custom relationType to Capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,11 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
   - `relatedCapabilities`: Array of `RelatedCapability` objects to link capabilities to other capabilities
   - Each relationship object includes the ORD ID of the related resource and an extensible `relationType`
 - Existing `relatedEntityTypes` property on `EntityType` has been extended to include `relationType` as well, for consistency and extensibility.
+- Added `x-deprecated-in-version` and `x-deprecation-text` information to the exported JSON Schema
 
 ### Changed
 
 - Made `RelatedEntityType.relationType` an extensible enum that now also accepts any valid [Concept ID](./docs/spec-v1/index.md#concept-id) in addition to the existing values (`part-of`, `can-share-identity`)
-- Added `x-deprecated-in-version` and `x-deprecation-text` information to the exported JSON Schema
 
 ## [1.14.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+### Added
+
+- Added relationship properties to `Capability` for expressing relations to other ORD resources:
+  - `relatedApiResources`: Array of `RelatedApiResource` objects to link capabilities to API resources
+  - `relatedEventResources`: Array of `RelatedEventResource` objects to link capabilities to event resources
+  - `relatedCapabilities`: Array of `RelatedCapability` objects to link capabilities to other capabilities
+- Added new definition objects `RelatedApiResource`, `RelatedEventResource`, and `RelatedCapability` with:
+  - `ordId`: Required reference to the target resource
+  - `relationType`: Optional [Concept ID](./docs/spec-v1/index.md#concept-id) to specify the semantic meaning of the relationship
+
+### Changed
+
+- Made `RelatedEntityType.relationType` an extensible enum that now also accepts any valid [Concept ID](./docs/spec-v1/index.md#concept-id) in addition to the existing values (`part-of`, `can-share-identity`)
+
 ## [1.14.1]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,8 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
   - `relatedApiResources`: Array of `RelatedApiResource` objects to link capabilities to API resources
   - `relatedEventResources`: Array of `RelatedEventResource` objects to link capabilities to event resources
   - `relatedCapabilities`: Array of `RelatedCapability` objects to link capabilities to other capabilities
-- Added new definition objects `RelatedApiResource`, `RelatedEventResource`, and `RelatedCapability` with:
-  - `ordId`: Required reference to the target resource
-  - `relationType`: Optional [Concept ID](./docs/spec-v1/index.md#concept-id) to specify the semantic meaning of the relationship
+  - Each relationship object includes the ORD ID of the related resource and an extensible `relationType`
+- Existing `relatedEntityTypes` property on `EntityType` has been extended to include `relationType` as well, for consistency and extensibility.
 
 ### Changed
 

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -3098,7 +3098,7 @@ definitions:
         items:
           $ref: "#/definitions/RelatedApiResource"
         examples:
-          - [{ "ordId": "sap.s4:apiResource:API_BUSINESS_PARTNER:v1", "relationType": "sap.ord:implements" }]
+          - [{ "ordId": "sap.s4:apiResource:API_BUSINESS_PARTNER:v1", "relationType": "foo.bar:relationName" }]
 
       relatedEventResources:
         type: array
@@ -3110,7 +3110,7 @@ definitions:
         items:
           $ref: "#/definitions/RelatedEventResource"
         examples:
-          - [{ "ordId": "sap.s4:eventResource:BusinessPartnerEvents:v1", "relationType": "sap.ord:emits" }]
+          - [{ "ordId": "sap.s4:eventResource:BusinessPartnerEvents:v1", "relationType": "foo.bar:relationName" }]
 
       relatedCapabilities:
         type: array
@@ -3122,7 +3122,7 @@ definitions:
         items:
           $ref: "#/definitions/RelatedCapability"
         examples:
-          - [{ "ordId": "sap.foo:capability:baseExtensibility:v1", "relationType": "sap.ord:extends" }]
+          - [{ "ordId": "sap.foo:capability:baseExtensibility:v1", "relationType": "foo.bar:relationName" }]
 
       definitions:
         <<: *resourceDefinitions
@@ -4811,6 +4811,7 @@ definitions:
               E.g. a `BusinessPartner` can share the same identity as a `NaturalPerson`.
         examples:
           - "can-share-identity"
+          - "foo.bar:relationName"
     required:
       - ordId
     additionalProperties: false
@@ -4933,8 +4934,7 @@ definitions:
             description: |-
               Any valid [Concept ID](../index.md#concept-id).
         examples:
-          - "sap.ord:extends"
-          - "sap.ord:requires"
+          - "foo.bar:relationName"
     required:
       - ordId
     additionalProperties: false

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -4851,8 +4851,7 @@ definitions:
             description: |-
               Any valid [Concept ID](../index.md#concept-id).
         examples:
-          - "sap.ord:implements"
-          - "sap.ord:consumes"
+          - "foo.bar:relationName"
     required:
       - ordId
     additionalProperties: false

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -3088,31 +3088,41 @@ definitions:
         examples:
           - ["sap.odm:entityType:WorkforcePerson:v1"]
 
-      # TODO: Clarify if we want to have relations to APIs and events like this
-      # Or if we should go with the generic relation concept
-      # relatedApiResources:
-      #   type: array
-      #   description: |-
-      #     Optional list of related API Resources.
+      relatedApiResources:
+        type: array
+        x-introduced-in-version: "1.15.0"
+        description: |-
+          Optional list of related API Resources.
 
-      #     MUST be a valid reference to an [API Resource](#api-resource) ORD ID.
-      #   items:
-      #     type: string
-      #     pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):(apiResource):([a-zA-Z0-9._\-]+):()$
-      #   examples:
-      #     - ['sap.s4:apiResource:API_RFQ_PROCESS_SRV:v2']
+          Use this to indicate which APIs implement, expose, or are otherwise related to this capability.
+        items:
+          $ref: "#/definitions/RelatedApiResource"
+        examples:
+          - [{ "ordId": "sap.s4:apiResource:API_BUSINESS_PARTNER:v1", "relationType": "sap.ord:implements" }]
 
-      # relatedEventResources:
-      #   type: array
-      #   description: |-
-      #     Optional list of related Event Resources.
+      relatedEventResources:
+        type: array
+        x-introduced-in-version: "1.15.0"
+        description: |-
+          Optional list of related Event Resources.
 
-      #     MUST be a valid reference to an [Event Resource](#event-resource) ORD ID.
-      #   items:
-      #     type: string
-      #     pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):(eventResource):([a-zA-Z0-9._\-]+):()$
-      #   examples:
-      #     - ['sap.s4:eventResource:BillofMaterialEvents:v1']
+          Use this to indicate which events are emitted, consumed, or otherwise related to this capability.
+        items:
+          $ref: "#/definitions/RelatedEventResource"
+        examples:
+          - [{ "ordId": "sap.s4:eventResource:BusinessPartnerEvents:v1", "relationType": "sap.ord:emits" }]
+
+      relatedCapabilities:
+        type: array
+        x-introduced-in-version: "1.15.0"
+        description: |-
+          Optional list of related Capabilities.
+
+          Use this to indicate dependencies, extensions, or other relationships between capabilities.
+        items:
+          $ref: "#/definitions/RelatedCapability"
+        examples:
+          - [{ "ordId": "sap.foo:capability:baseExtensibility:v1", "relationType": "sap.ord:extends" }]
 
       definitions:
         <<: *resourceDefinitions
@@ -4781,9 +4791,15 @@ definitions:
           Optional type of the relationship, which defines a stricter semantic what the relationship implies.
 
           If not provided, the relationship type has no semantics, it's "related somehow".
+
+          MUST be a valid [Concept ID](../index.md#concept-id).
         x-introduced-in-version: "1.12.0"
         x-feature-status: beta
-        oneOf:
+        anyOf: # Extensible enum. See https://opensource.zalando.com/restful-api-guidelines/#112
+          - type: string
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+)$
+            description: |-
+              Any valid [Concept ID](../index.md#concept-id).
           - const: part-of
             description: |-
               The described entity type is a composite part of the referenced entity type.
@@ -4795,6 +4811,132 @@ definitions:
               E.g. a `BusinessPartner` can share the same identity as a `NaturalPerson`.
         examples:
           - "can-share-identity"
+    required:
+      - ordId
+    additionalProperties: false
+
+  ############################################################################################################
+
+  RelatedApiResource:
+    title: Related API Resource
+    x-introduced-in-version: "1.15.0"
+    x-ums-type: "embedded"
+    type: object
+    description: |-
+      Defines a relation to an API Resource (via its ORD ID).
+    properties:
+      ordId:
+        <<: *ordId
+        pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):(apiResource):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+        x-association-target:
+          - "#/definitions/ApiResource/ordId"
+        x-ums-reverse-relationship:
+          propertyName: capabilities
+          description: |-
+            Capabilities related to this API Resource.
+          min: 0
+          max: "*"
+        examples:
+          - "sap.s4:apiResource:API_BUSINESS_PARTNER:v1"
+      relationType:
+        type: string
+        description: |-
+          Optional type of the relationship as a [Concept ID](../index.md#concept-id).
+
+          Defines the semantic meaning of the relationship.
+          If not provided, the relationship has no specific semantics ("related somehow").
+        anyOf: # Extensible enum. See https://opensource.zalando.com/restful-api-guidelines/#112
+          - type: string
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+)$
+            description: |-
+              Any valid [Concept ID](../index.md#concept-id).
+        examples:
+          - "sap.ord:implements"
+          - "sap.ord:consumes"
+    required:
+      - ordId
+    additionalProperties: false
+
+  ############################################################################################################
+
+  RelatedEventResource:
+    title: Related Event Resource
+    x-introduced-in-version: "1.15.0"
+    x-ums-type: "embedded"
+    type: object
+    description: |-
+      Defines a relation to an Event Resource (via its ORD ID).
+    properties:
+      ordId:
+        <<: *ordId
+        pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):(eventResource):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+        x-association-target:
+          - "#/definitions/EventResource/ordId"
+        x-ums-reverse-relationship:
+          propertyName: capabilities
+          description: |-
+            Capabilities related to this Event Resource.
+          min: 0
+          max: "*"
+        examples:
+          - "sap.s4:eventResource:BusinessPartnerEvents:v1"
+      relationType:
+        type: string
+        description: |-
+          Optional type of the relationship as a [Concept ID](../index.md#concept-id).
+
+          Defines the semantic meaning of the relationship.
+          If not provided, the relationship has no specific semantics ("related somehow").
+        anyOf: # Extensible enum. See https://opensource.zalando.com/restful-api-guidelines/#112
+          - type: string
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+)$
+            description: |-
+              Any valid [Concept ID](../index.md#concept-id).
+        examples:
+          - "sap.ord:emits"
+          - "sap.ord:subscribes"
+    required:
+      - ordId
+    additionalProperties: false
+
+  ############################################################################################################
+
+  RelatedCapability:
+    title: Related Capability
+    x-introduced-in-version: "1.15.0"
+    x-ums-type: "embedded"
+    type: object
+    description: |-
+      Defines a relation to another Capability (via its ORD ID).
+    properties:
+      ordId:
+        <<: *ordId
+        pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):(capability):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+        x-association-target:
+          - "#/definitions/Capability/ordId"
+        x-ums-reverse-relationship:
+          propertyName: inverseRelatedCapabilities
+          description: |-
+            Capabilities that declared a relationship to this capability.
+          min: 0
+          max: "*"
+        examples:
+          - "sap.foo:capability:fieldExtensibility:v1"
+      relationType:
+        type: string
+        description: |-
+          Optional type of the relationship as a [Concept ID](../index.md#concept-id).
+
+          Defines the semantic meaning of the relationship.
+          If not provided, the relationship has no specific semantics ("related somehow").
+        anyOf: # Extensible enum. See https://opensource.zalando.com/restful-api-guidelines/#112
+          - type: string
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+)$
+            description: |-
+              Any valid [Concept ID](../index.md#concept-id).
+        examples:
+          - "sap.ord:extends"
+          - "sap.ord:requires"
     required:
       - ordId
     additionalProperties: false

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -3090,7 +3090,7 @@ definitions:
 
       relatedApiResources:
         type: array
-        x-introduced-in-version: "1.15.0"
+        x-introduced-in-version: "1.14.3"
         description: |-
           Optional list of related API Resources.
 
@@ -3102,7 +3102,7 @@ definitions:
 
       relatedEventResources:
         type: array
-        x-introduced-in-version: "1.15.0"
+        x-introduced-in-version: "1.14.3"
         description: |-
           Optional list of related Event Resources.
 
@@ -3114,7 +3114,7 @@ definitions:
 
       relatedCapabilities:
         type: array
-        x-introduced-in-version: "1.15.0"
+        x-introduced-in-version: "1.14.3"
         description: |-
           Optional list of related Capabilities.
 
@@ -4819,7 +4819,7 @@ definitions:
 
   RelatedApiResource:
     title: Related API Resource
-    x-introduced-in-version: "1.15.0"
+    x-introduced-in-version: "1.14.3"
     x-ums-type: "embedded"
     type: object
     description: |-
@@ -4861,7 +4861,7 @@ definitions:
 
   RelatedEventResource:
     title: Related Event Resource
-    x-introduced-in-version: "1.15.0"
+    x-introduced-in-version: "1.14.3"
     x-ums-type: "embedded"
     type: object
     description: |-
@@ -4903,7 +4903,7 @@ definitions:
 
   RelatedCapability:
     title: Related Capability
-    x-introduced-in-version: "1.15.0"
+    x-introduced-in-version: "1.14.3"
     x-ums-type: "embedded"
     type: object
     description: |-

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -4892,8 +4892,7 @@ definitions:
             description: |-
               Any valid [Concept ID](../index.md#concept-id).
         examples:
-          - "sap.ord:emits"
-          - "sap.ord:subscribes"
+          - "foo.bar:relationName"
     required:
       - ordId
     additionalProperties: false

--- a/src/generated/spec/v1/types/Document.ts
+++ b/src/generated/spec/v1/types/Document.ts
@@ -1931,8 +1931,10 @@ export interface RelatedEntityType {
    * Optional type of the relationship, which defines a stricter semantic what the relationship implies.
    *
    * If not provided, the relationship type has no semantics, it's "related somehow".
+   *
+   * MUST be a valid [Concept ID](../index.md#concept-id).
    */
-  relationType?: "part-of" | "can-share-identity";
+  relationType?: (string | "part-of" | "can-share-identity") & string;
 }
 /**
  * Capabilities can be used to describe use case specific capabilities, most notably supported features or additional information (like configuration) that needs to be understood from outside.
@@ -2097,6 +2099,24 @@ export interface Capability {
    */
   relatedEntityTypes?: string[];
   /**
+   * Optional list of related API Resources.
+   *
+   * Use this to indicate which APIs implement, expose, or are otherwise related to this capability.
+   */
+  relatedApiResources?: RelatedAPIResource[];
+  /**
+   * Optional list of related Event Resources.
+   *
+   * Use this to indicate which events are emitted, consumed, or otherwise related to this capability.
+   */
+  relatedEventResources?: RelatedEventResource[];
+  /**
+   * Optional list of related Capabilities.
+   *
+   * Use this to indicate dependencies, extensions, or other relationships between capabilities.
+   */
+  relatedCapabilities?: RelatedCapability[];
+  /**
    * List of available machine-readable definitions, which describe the resource or capability in detail.
    * See also [Resource Definitions](../index.md#resource-definitions) for more context.
    *
@@ -2135,6 +2155,60 @@ export interface Capability {
    * For more details, see [perspectives concept page](../concepts/perspectives.md) or the [specification section](../index.md#perspectives).
    */
   systemInstanceAware?: boolean;
+}
+/**
+ * Defines a relation to an API Resource (via its ORD ID).
+ */
+export interface RelatedAPIResource {
+  /**
+   * The ORD ID is a stable, globally unique ID for ORD resources or taxonomy.
+   *
+   * It MUST be a valid [ORD ID](../index.md#ord-id) of the appropriate ORD type.
+   */
+  ordId: string;
+  /**
+   * Optional type of the relationship as a [Concept ID](../index.md#concept-id).
+   *
+   * Defines the semantic meaning of the relationship.
+   * If not provided, the relationship has no specific semantics ("related somehow").
+   */
+  relationType?: string;
+}
+/**
+ * Defines a relation to an Event Resource (via its ORD ID).
+ */
+export interface RelatedEventResource {
+  /**
+   * The ORD ID is a stable, globally unique ID for ORD resources or taxonomy.
+   *
+   * It MUST be a valid [ORD ID](../index.md#ord-id) of the appropriate ORD type.
+   */
+  ordId: string;
+  /**
+   * Optional type of the relationship as a [Concept ID](../index.md#concept-id).
+   *
+   * Defines the semantic meaning of the relationship.
+   * If not provided, the relationship has no specific semantics ("related somehow").
+   */
+  relationType?: string;
+}
+/**
+ * Defines a relation to another Capability (via its ORD ID).
+ */
+export interface RelatedCapability {
+  /**
+   * The ORD ID is a stable, globally unique ID for ORD resources or taxonomy.
+   *
+   * It MUST be a valid [ORD ID](../index.md#ord-id) of the appropriate ORD type.
+   */
+  ordId: string;
+  /**
+   * Optional type of the relationship as a [Concept ID](../index.md#concept-id).
+   *
+   * Defines the semantic meaning of the relationship.
+   * If not provided, the relationship has no specific semantics ("related somehow").
+   */
+  relationType?: string;
 }
 /**
  * Link and categorization of a machine-readable capability definition.

--- a/static/spec-v1/interfaces/ums/MetadataType/apiresource.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/apiresource.yaml
@@ -424,3 +424,8 @@ spec:
       relatedTypeName: 'Extensible'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       description: "Describes extensibility (by customers or partners) of this resource.\nExtensibility usually happens at run-time by the end-users.\nExtensions can be field or entity extensions that come on top of the baseline contract.\n\nChanges in extensions do not lead to an increase in the `version`, but MUST lead to an updated `lastUpdate` date.\n\nSince the extensions are managed by the customer or a partner, whether those changes are compatible or not is not guaranteed by the base contract of the resource."
+    - propertyName: 'capabilities'
+      relatedTypeName: 'RelatedApiResource'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      description: 'Capabilities related to this API Resource.'
+      mandatory: false

--- a/static/spec-v1/interfaces/ums/MetadataType/capability.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/capability.yaml
@@ -229,3 +229,20 @@ spec:
       description: "Optional list of related EntityType Resources.\nMUST be a valid reference to an [EntityType Resource](#entity-type) ORD ID."
       reverseRelation:
         relationPropertyName: 'capabilities'
+    - propertyName: 'relatedApiResources'
+      relatedTypeName: 'RelatedApiResource'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      description: "Optional list of related API Resources.\n\nUse this to indicate which APIs implement, expose, or are otherwise related to this capability."
+    - propertyName: 'relatedEventResources'
+      relatedTypeName: 'RelatedEventResource'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      description: "Optional list of related Event Resources.\n\nUse this to indicate which events are emitted, consumed, or otherwise related to this capability."
+    - propertyName: 'relatedCapabilities'
+      relatedTypeName: 'RelatedCapability'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      description: "Optional list of related Capabilities.\n\nUse this to indicate dependencies, extensions, or other relationships between capabilities."
+    - propertyName: 'inverseRelatedCapabilities'
+      relatedTypeName: 'RelatedCapability'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      description: 'Capabilities that declared a relationship to this capability.'
+      mandatory: false

--- a/static/spec-v1/interfaces/ums/MetadataType/eventresource.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/eventresource.yaml
@@ -406,3 +406,8 @@ spec:
       relatedTypeName: 'Extensible'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       description: "Describes extensibility (by customers or partners) of this resource.\nExtensibility usually happens at run-time by the end-users.\nExtensions can be field or entity extensions that come on top of the baseline contract.\n\nChanges in extensions do not lead to an increase in the `version`, but MUST lead to an updated `lastUpdate` date.\n\nSince the extensions are managed by the customer or a partner, whether those changes are compatible or not is not guaranteed by the base contract of the resource."
+    - propertyName: 'capabilities'
+      relatedTypeName: 'RelatedEventResource'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      description: 'Capabilities related to this Event Resource.'
+      mandatory: false

--- a/static/spec-v1/interfaces/ums/MetadataType/relatedapiresource.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/relatedapiresource.yaml
@@ -1,16 +1,16 @@
 apiVersion: 'metadata-service.resource.api.sap/v6alpha1'
 type: 'MetadataType'
 metadata:
-  name: 'relatedentitytype'
+  name: 'relatedapiresource'
   path: '/sap/core/ucl/metadata/ord/v1'
   labels: {}
 spec:
-  typeName: 'RelatedEntityType'
+  typeName: 'RelatedApiResource'
   key:
     - 'id'
   visibility: 'public'
   embedded: true
-  description: 'Defines the relation between Entity Types (via its ORD ID).'
+  description: 'Defines a relation to an API Resource (via its ORD ID).'
   metadataProperties:
     - name: 'id'
       type: 'guid'
@@ -23,18 +23,18 @@ spec:
       mandatory: true
       constraints:
         maxLength: 255
-        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(entityType):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(apiResource):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
     - name: 'relationType'
       type: 'string'
-      description: "Optional type of the relationship, which defines a stricter semantic what the relationship implies.\n\nIf not provided, the relationship type has no semantics, it's \"related somehow\".\n\nMUST be a valid [Concept ID](../index.md#concept-id)."
+      description: "Optional type of the relationship as a [Concept ID](../index.md#concept-id).\n\nDefines the semantic meaning of the relationship.\nIf not provided, the relationship has no specific semantics (\"related somehow\")."
   customTypeDefinitions: []
   metadataRelations:
     - propertyName: 'ordId'
-      relatedTypeName: 'EntityType'
+      relatedTypeName: 'ApiResource'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       propertyBased: true
       managedByProperty: 'ordId_ID'
       description: "The ORD ID is a stable, globally unique ID for ORD resources or taxonomy.\n\nIt MUST be a valid [ORD ID](../index.md#ord-id) of the appropriate ORD type."
       mandatory: true
       reverseRelation:
-        relationPropertyName: 'inverseRelatedEntityTypes'
+        relationPropertyName: 'capabilities'

--- a/static/spec-v1/interfaces/ums/MetadataType/relatedcapability.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/relatedcapability.yaml
@@ -1,16 +1,16 @@
 apiVersion: 'metadata-service.resource.api.sap/v6alpha1'
 type: 'MetadataType'
 metadata:
-  name: 'relatedentitytype'
+  name: 'relatedcapability'
   path: '/sap/core/ucl/metadata/ord/v1'
   labels: {}
 spec:
-  typeName: 'RelatedEntityType'
+  typeName: 'RelatedCapability'
   key:
     - 'id'
   visibility: 'public'
   embedded: true
-  description: 'Defines the relation between Entity Types (via its ORD ID).'
+  description: 'Defines a relation to another Capability (via its ORD ID).'
   metadataProperties:
     - name: 'id'
       type: 'guid'
@@ -23,18 +23,18 @@ spec:
       mandatory: true
       constraints:
         maxLength: 255
-        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(entityType):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(capability):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
     - name: 'relationType'
       type: 'string'
-      description: "Optional type of the relationship, which defines a stricter semantic what the relationship implies.\n\nIf not provided, the relationship type has no semantics, it's \"related somehow\".\n\nMUST be a valid [Concept ID](../index.md#concept-id)."
+      description: "Optional type of the relationship as a [Concept ID](../index.md#concept-id).\n\nDefines the semantic meaning of the relationship.\nIf not provided, the relationship has no specific semantics (\"related somehow\")."
   customTypeDefinitions: []
   metadataRelations:
     - propertyName: 'ordId'
-      relatedTypeName: 'EntityType'
+      relatedTypeName: 'Capability'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       propertyBased: true
       managedByProperty: 'ordId_ID'
       description: "The ORD ID is a stable, globally unique ID for ORD resources or taxonomy.\n\nIt MUST be a valid [ORD ID](../index.md#ord-id) of the appropriate ORD type."
       mandatory: true
       reverseRelation:
-        relationPropertyName: 'inverseRelatedEntityTypes'
+        relationPropertyName: 'inverseRelatedCapabilities'

--- a/static/spec-v1/interfaces/ums/MetadataType/relatedeventresource.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/relatedeventresource.yaml
@@ -1,16 +1,16 @@
 apiVersion: 'metadata-service.resource.api.sap/v6alpha1'
 type: 'MetadataType'
 metadata:
-  name: 'relatedentitytype'
+  name: 'relatedeventresource'
   path: '/sap/core/ucl/metadata/ord/v1'
   labels: {}
 spec:
-  typeName: 'RelatedEntityType'
+  typeName: 'RelatedEventResource'
   key:
     - 'id'
   visibility: 'public'
   embedded: true
-  description: 'Defines the relation between Entity Types (via its ORD ID).'
+  description: 'Defines a relation to an Event Resource (via its ORD ID).'
   metadataProperties:
     - name: 'id'
       type: 'guid'
@@ -23,18 +23,18 @@ spec:
       mandatory: true
       constraints:
         maxLength: 255
-        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(entityType):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(eventResource):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
     - name: 'relationType'
       type: 'string'
-      description: "Optional type of the relationship, which defines a stricter semantic what the relationship implies.\n\nIf not provided, the relationship type has no semantics, it's \"related somehow\".\n\nMUST be a valid [Concept ID](../index.md#concept-id)."
+      description: "Optional type of the relationship as a [Concept ID](../index.md#concept-id).\n\nDefines the semantic meaning of the relationship.\nIf not provided, the relationship has no specific semantics (\"related somehow\")."
   customTypeDefinitions: []
   metadataRelations:
     - propertyName: 'ordId'
-      relatedTypeName: 'EntityType'
+      relatedTypeName: 'EventResource'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       propertyBased: true
       managedByProperty: 'ordId_ID'
       description: "The ORD ID is a stable, globally unique ID for ORD resources or taxonomy.\n\nIt MUST be a valid [ORD ID](../index.md#ord-id) of the appropriate ORD type."
       mandatory: true
       reverseRelation:
-        relationPropertyName: 'inverseRelatedEntityTypes'
+        relationPropertyName: 'capabilities'


### PR DESCRIPTION
### Added

- Added relationship properties to `Capability` for expressing relations to other ORD resources:
  - `relatedApiResources`: Array of `RelatedApiResource` objects to link capabilities to API resources
  - `relatedEventResources`: Array of `RelatedEventResource` objects to link capabilities to event resources
  - `relatedCapabilities`: Array of `RelatedCapability` objects to link capabilities to other capabilities
  - Each relationship object includes the ORD ID of the related resource and an extensible `relationType`
- Existing `relatedEntityTypes` property on `EntityType` has been extended to include `relationType` as well, for consistency and extensibility.