### PR TITLE
Fix diagram readability in dark mode

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -113,7 +113,7 @@ const config = {
         darkTheme: prismThemes.oceanicNext,
       },
       mermaid: {
-        theme: { light: "neutral", dark: "dark" },
+        theme: { light: "neutral", dark: "neutral" },
       },
       navbar: {
         title: "Open Resource Discovery",

--- a/static/css/components/markdown/index.css
+++ b/static/css/components/markdown/index.css
@@ -325,3 +325,15 @@ html {
   color: var(--c-accent) !important;
   text-decoration-color: var(--c-accent);
 }
+
+html[data-theme="dark"] #__docusaurus:not(:has(.ord-home-flag)) .theme-doc-markdown.markdown .docusaurus-mermaid-container,
+html[data-theme="dark"] #__docusaurus:not(:has(.ord-home-flag)) .theme-doc-markdown.markdown .docusaurus-mermaid-container > svg,
+html[data-theme="dark"] #__docusaurus:not(:has(.ord-home-flag)) .theme-doc-markdown.markdown .docusaurus-mermaid-container svg[id^="mermaid-svg-"] {
+  background: #fff !important;
+  border-radius: 8px;
+}
+
+html[data-theme="dark"] #__docusaurus:not(:has(.ord-home-flag)) .theme-doc-markdown.markdown img {
+  background: #fff !important;
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Summary
Add a white background for diagrams and images in dark mode to improve readability on GitHub Pages.

## Changes
- use a neutral Mermaid theme in light and dark mode
- add dark mode CSS override for Mermaid diagrams and markdown images

## Result
Diagrams with dark text stay readable in dark mode with minimal styling changes.