### PR TITLE
Improve `deprecated` releaseStatus documentation

### DIFF
--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -1062,7 +1062,7 @@ definitions:
               Breaking changes may occur at any time without notice or deprecation period.
 
               Not recommended for production use unless you can tolerate breaking changes. Suitable for experimentation, early adopters,
-              and feedback gathering. Resources of `beta` status MAY be changed or removed at the provider's discretion.
+              and feedback gathering. Resources of `beta` `releaseStatus` MAY be changed or removed at the provider's discretion.
 
           - const: active
             description: |-
@@ -1076,6 +1076,7 @@ definitions:
               The resource is still functional but scheduled for removal. No new development should depend on it.
 
               If the `releaseStatus` is set to `deprecated`, the `deprecationDate` SHOULD be provided.
+              If the `releaseStatus` is set to `deprecated`, and the `sunsetDate` is already known, then the `sunsetDate` SHOULD be provided.
 
               If successor resources exist, they MUST be referenced through `successors`.
 
@@ -1086,7 +1087,7 @@ definitions:
             description: |-
               The resource has been decommissioned and is no longer available at runtime. This entry exists for historical reference only.
 
-              If the status is set to `sunset`, a `Tombstone` MUST be set as well and a `sunsetDate` MUST be provided.
+              If the `releaseStatus` is set to `sunset`, a `Tombstone` MUST be set as well and a `sunsetDate` MUST be provided.
         examples:
           - active
 


### PR DESCRIPTION
The same sentence that was only visible at `sunsetDate` 
<img width="972" height="243" alt="image" src="https://github.com/user-attachments/assets/a0b7938c-0a62-4c0d-9837-cbbc9aa1df9c" />

should be also mirrored at the `releaseStatus` property.