### PR TITLE
Recommend labels key to be Concept ID to clarify ownership and avoid conflicts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,8 +2,5 @@
   "contextFiles": [
     "AGENTS.md",
     "package.json"
-  ],
-  "hooks": {
-    "beforeCommit": "npm run lint && npm run test"
-  }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+### Changed
+
+- Added recommendation to use [Concept IDs](./docs/spec-v1/index.md#concept-id) as `labels` keys to indicate ownership and avoid naming conflicts.
+
 ## [1.14.3]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ### Changed
 
-- Added recommendation to use [Concept IDs](./docs/spec-v1/index.md#concept-id) as `labels` keys to indicate ownership and avoid naming conflicts.
+- Added recommendation to use [Concept IDs](https://open-resource-discovery.org/spec-v1#concept-id) as `labels` keys to indicate ownership and avoid naming conflicts.
 
 ## [1.14.3]
 

--- a/examples/documents/document-1.json
+++ b/examples/documents/document-1.json
@@ -26,7 +26,7 @@
       "vendor": "sap:vendor:SAP:",
       "tags": ["reference application"],
       "labels": {
-        "sap.foo:custom-label": ["labels are more flexible than tags as you can define your own keys"]
+        "foo.bar:custom-label": ["labels are more flexible than tags as you can define your own keys"]
       },
       "documentationLabels": {
         "Some Aspect": ["Markdown Documentation [with links](#)", "With multiple values"]

--- a/examples/documents/document-1.json
+++ b/examples/documents/document-1.json
@@ -26,7 +26,7 @@
       "vendor": "sap:vendor:SAP:",
       "tags": ["reference application"],
       "labels": {
-        "customLabel": ["labels are more flexible than tags as you can define your own keys"]
+        "sap.foo:custom-label": ["labels are more flexible than tags as you can define your own keys"]
       },
       "documentationLabels": {
         "Some Aspect": ["Markdown Documentation [with links](#)", "With multiple values"]

--- a/examples/documents/document-agents.json
+++ b/examples/documents/document-agents.json
@@ -94,7 +94,7 @@
       "exposedApiResources": [{"ordId": "sap.foo:apiResource:DisputeResolutionAgent:v1"}],
       "integrationDependencies": ["sap.foo:integrationDependency:DisputeCaseManagement:v1"],
       "labels": {
-        "interactionMode": ["conversational", "system-triggered"]
+        "foo.ai:interaction-mode": ["conversational", "system-triggered"]
       },
       "tags": ["finance", "billing", "dispute-resolution", "invoicing", "ai-agent"],
       "links": [

--- a/examples/documents/document-data-product.json
+++ b/examples/documents/document-data-product.json
@@ -185,7 +185,7 @@
       "lineOfBusiness": ["Sales"],
       "tags": ["CustomerOrder", "Order", "Online Sales", "Offline Sales"],
       "labels": {
-        "label-key-1": ["label-value-1", "label-value-2"]
+        "sap.xref:cost-center": ["CC-12345", "CC-67890"]
       },
       "documentationLabels": {
         "Scope Items": [
@@ -376,7 +376,7 @@
       "industry": ["Retail", "Consumer Products"],
       "tags": ["Commerce"],
       "labels": {
-        "label-key-1": ["label-value-1", "label-value-2"]
+        "sap.xref:cost-center": ["CC-12345", "CC-67890"]
       },
       "documentationLabels": {
         "Expected Access Performance ": ["free text/markdown"]
@@ -489,7 +489,7 @@
       "industry": ["Retail", "Consumer Products"],
       "tags": ["Commerce"],
       "labels": {
-        "label-key-1": ["label-value-1", "label-value-2"]
+        "sap.xref:cost-center": ["CC-12345", "CC-67890"]
       },
       "documentationLabels": {
         "Expected Access Performance ": ["free text/markdown"]
@@ -557,7 +557,7 @@
       "industry": ["Retail", "Consumer Products"],
       "tags": ["Commerce"],
       "labels": {
-        "label-key-1": ["label-value-1", "label-value-2"]
+        "sap.xref:cost-center": ["CC-12345", "CC-67890"]
       },
       "documentationLabels": {
         "Expected Access Performance ": ["free text/markdown"]
@@ -653,7 +653,7 @@
       "industry": ["Retail", "Consumer Products"],
       "tags": ["Commerce"],
       "labels": {
-        "label-key-1": ["label-value-1", "label-value-2"]
+        "sap.xref:cost-center": ["CC-12345", "CC-67890"]
       },
       "documentationLabels": {
         "Expected Access Performance ": ["free text/markdown"]

--- a/examples/documents/document-data-product.json
+++ b/examples/documents/document-data-product.json
@@ -185,7 +185,7 @@
       "lineOfBusiness": ["Sales"],
       "tags": ["CustomerOrder", "Order", "Online Sales", "Offline Sales"],
       "labels": {
-        "sap.xref:cost-center": ["CC-12345", "CC-67890"]
+        "foo.bar:cost-center": ["CC-12345", "CC-67890"]
       },
       "documentationLabels": {
         "Scope Items": [
@@ -376,7 +376,7 @@
       "industry": ["Retail", "Consumer Products"],
       "tags": ["Commerce"],
       "labels": {
-        "sap.xref:cost-center": ["CC-12345", "CC-67890"]
+        "foo.bar:cost-center": ["CC-12345", "CC-67890"]
       },
       "documentationLabels": {
         "Expected Access Performance ": ["free text/markdown"]
@@ -489,7 +489,7 @@
       "industry": ["Retail", "Consumer Products"],
       "tags": ["Commerce"],
       "labels": {
-        "sap.xref:cost-center": ["CC-12345", "CC-67890"]
+        "foo.bar:cost-center": ["CC-12345", "CC-67890"]
       },
       "documentationLabels": {
         "Expected Access Performance ": ["free text/markdown"]
@@ -557,7 +557,7 @@
       "industry": ["Retail", "Consumer Products"],
       "tags": ["Commerce"],
       "labels": {
-        "sap.xref:cost-center": ["CC-12345", "CC-67890"]
+        "foo.bar:cost-center": ["CC-12345", "CC-67890"]
       },
       "documentationLabels": {
         "Expected Access Performance ": ["free text/markdown"]
@@ -653,7 +653,7 @@
       "industry": ["Retail", "Consumer Products"],
       "tags": ["Commerce"],
       "labels": {
-        "sap.xref:cost-center": ["CC-12345", "CC-67890"]
+        "foo.bar:cost-center": ["CC-12345", "CC-67890"]
       },
       "documentationLabels": {
         "Expected Access Performance ": ["free text/markdown"]

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -4368,7 +4368,7 @@ definitions:
           minLength: 1
     examples:
       - foo.bar:labelKeyName: ["value"]
-      - acme.billing:cost-center: ["CC-12345", "CC-67890"]
+      - foo.bar:cost-center: ["CC-12345", "CC-67890"]
 
   ############################################################################################################
 

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -4356,6 +4356,9 @@ definitions:
       Duplicate labels will be merged by the ORD aggregator according to the following rules:
       * Values of the same label key will be merged.
       * Duplicate values of the same label key will be removed.
+
+      **RECOMMENDATION**: Use a [Concept ID](../index.md#concept-id) as the label key to indicate ownership and avoid naming conflicts.
+      The namespace in the Concept ID clearly identifies who owns and defines the label's semantics.
     x-ums-type: "custom"
     patternProperties:
       "^[a-zA-Z0-9-_.]*$":
@@ -4364,7 +4367,8 @@ definitions:
           type: string
           minLength: 1
     examples:
-      - label-key-1: ["label-value-1", "label-value-2"]
+      - foo.bar:labelKeyName: ["value"]
+      - acme.billing:cost-center: ["CC-12345", "CC-67890"]
 
   ############################################################################################################
 

--- a/src/generated/spec/v1/types/Document.ts
+++ b/src/generated/spec/v1/types/Document.ts
@@ -204,6 +204,9 @@ export interface SystemInstance {
  * Duplicate labels will be merged by the ORD aggregator according to the following rules:
  * * Values of the same label key will be merged.
  * * Duplicate values of the same label key will be removed.
+ *
+ * **RECOMMENDATION**: Use a [Concept ID](../index.md#concept-id) as the label key to indicate ownership and avoid naming conflicts.
+ * The namespace in the Concept ID clearly identifies who owns and defines the label's semantics.
  */
 export interface Labels {
   /**


### PR DESCRIPTION
### Changed

- Added recommendation to use [Concept IDs](https://open-resource-discovery.org/spec-v1#concept-id) as `labels` keys to indicate ownership and avoid naming conflicts.