### PR TITLE
Clarify system-perspective fallback from system-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 ### Changed
 
 - Added recommendation to use [Concept IDs](https://open-resource-discovery.org/spec-v1#concept-id) as `labels` keys to indicate ownership and avoid naming conflicts.
+- Clarification: Consolidated and clarified the [static perspective resolution](https://open-resource-discovery.org/spec-v1/concepts/perspectives#static-perspective-resolution) algorithm for aggregators. When no specific version is requested, explicit `system-type` perspective data takes precedence; if unavailable, the aggregator SHOULD derive it from the latest `system-version`. Previously this behavior was scattered and only stated as MAY.
 
 ## [1.14.3]
 

--- a/docs/spec-v1/concepts/perspectives.md
+++ b/docs/spec-v1/concepts/perspectives.md
@@ -137,7 +137,7 @@ If the aggregator supports both static and dynamic perspectives:
 
 - The ORD aggregator MUST be able to aggregate and store all perspectives (`system-type`, `system-version`, and `system-instance`) at the same time.
 - In its ORD Discovery API for consumers, it needs to implement the inheritance / fallback behavior:
-  - When `system-instance` is requested but not available, fall back to `system-version`.
+  - When `system-instance` is requested but not available, fall back to `system-version`, when this is not available fall back to `system-type`.
   - Static perspective resolution (when `system-type` or `system-version` is requested) SHOULD follow the algorithm described [below](#static-perspective-resolution).
 
 #### Static Perspective Resolution

--- a/docs/spec-v1/concepts/perspectives.md
+++ b/docs/spec-v1/concepts/perspectives.md
@@ -44,6 +44,8 @@ Here are some guidelines how to choose the correct version for the `system-versi
   - However, consider that you may still have different releases rolled out over time and on different stages. If this causes a problem, use `system-version` with below conventions.
   - Alternatively, use a fixed `1.0.0` version and overwrite it with every new release.
 
+For the normative rules on choosing between `system-type` and `system-version`, see [Correct Use of Perspectives](../../spec-v1/index.md#correct-use-of-perspectives).
+
 ### Dynamic Perspective
 
 The dynamic perspective describes an application or service as it really looks like, _at run-time_.
@@ -99,6 +101,8 @@ The `perspectives` attribute deprecates the `systemInstanceAware` attribute.
 
 With `systemInstanceAware` it was already possible to define whether metadata was dynamic (different per system instance) or not.
 But the concept did not allow to describe the same resource in different perspectives and also did not define how the perspectives build upon each other.
+
+To migrate: replace `systemInstanceAware: true` with `perspective: "system-instance"` and split your ORD document so that static and dynamic metadata are in separate documents with their respective perspective set. See the [ORD Configuration interface](../../spec-v1/interfaces/Configuration.md#ord-v1-document-description_perspective) for the `perspective` property details.
 
 ## ORD Provider Considerations
 

--- a/docs/spec-v1/concepts/perspectives.md
+++ b/docs/spec-v1/concepts/perspectives.md
@@ -9,21 +9,21 @@ description: Metadata can be described from static or dynamic perspectives. This
 
 ## Overview
 
-An application or service can be described both from a static or a dynamic perspective. The configuration endpoint can point to different ORD documents that represent the information from the different perspectives.
+An application or service can be described both from a [static](../../spec-v1/index.md#static-perspective) or a [dynamic](../../spec-v1/index.md#dynamic-perspective) perspective. The configuration endpoint can point to different ORD documents that represent the information from the different perspectives.
 
 ### Static Perspective
 
-The static `system-version` or `system-type` perspective describes how an application or services looks like _in general_ at design-time.
+The static perspective describes how an application or service looks like _in general_ at design-time.
 This perspective is especially useful for customers, who haven't purchased a product yet and need to understand what technical capabilities they would get.
 It also helps to understand the common baseline of what all systems of the same type provide and how it changes over time.
 
-In ORD, we describe this with `perspective`: `system-version`, to hint at the fact that the static metadata is usually version dependent.
-Static metadata is known at design-time or deploy-time, when a new version of an application or service is developed or provisioned.
+The static perspective has two sub-levels:
+
+- **`system-version`**: Describes the metadata for a specific version of a [system type](../../spec-v1/index.md#system-type). Static metadata is known at design-time or deploy-time, when a new version of an application or service is developed or provisioned. Use this when the system has explicit versions.
+- **`system-type`**: Describes version-independent metadata that applies no matter which [system version](../../spec-v1/index.md#system-version) or [system instance](../../spec-v1/index.md#system-instance) is used. Use this when the system is not versioned (continuous delivery) or resources do not relate to a specific system version.
+
 For cloud software with continuous delivery, the version may not be explicit or of interest to the consumer, a fallback to a "latest" version may be needed.
 But consider that also cloud software that is going through phased deployments therefore can have multiple versions active at the same time.
-
-In the case that the system is not versioned (continuous delivery) or resources do not relate to a system directly, the `system-type` perspective can be used.
-The `system-type` information apply no matter which system version or instance is used.
 
 The static perspective describes the shared metadata of all system instances (tenants) of the same system version or version independent.
 Either the metadata is always the same or it explicitly ignores the tenant-specific extensibility, configuration and any feature toggles - describing what's generic and shared.
@@ -83,6 +83,8 @@ This is depicted in the following diagram:
 The `system-instance` perspective is the most specific, because a consumer could ask how a particular system instance / tenant really looks like. If there is system-instance metadata for it, we can return it directly.
 If we don't have it, we need to fall back to the `system-version` layer and instead return the metadata for the version of the system instance.
 
+Note that perspectives do not merge: when a more specific perspective is available, it completely replaces the less specific one. For example, if `system-instance` metadata is published for a resource, it fully overrides the `system-version` description of that resource — the two are not combined.
+
 If no explicit `system-type` perspective has been published, the aggregator SHOULD derive it from the latest `system-version` perspective (see [Static Perspective Resolution](#static-perspective-resolution) below).
 
 A consumer can legitimately be interested in all three levels, but needs to provide a different context for each:
@@ -107,9 +109,32 @@ The following diagram gives an overview which perspectives need to be described 
 If the system has only static metadata, it should explicitly use the `system-version` perspective and state its version (`describedSystemVersion`).
 If the system has dynamic metadata, it should describe both perspectives completely, if possible.
 
+If the `system-version` perspective is used, the described version MUST be provided via the ORD `describedSystemVersion`.`version` property.
+For the `system-type` perspective, the version property is NOT required as this perspective is version-independent.
+Ideally, ORD providers SHOULD define the `describedSystemVersion`.`version` property on both the `system-version` and `system-instance` perspectives.
+
+The `version` becomes effectively the "join" criteria for how the dynamic metadata is associated to the version-specific static metadata.
+
 > ⏩ See also: [Correct Use of Perspectives](../../spec-v1/index.md#correct-use-of-perspectives).
 
 ## ORD Aggregator Considerations
+
+#### Static Aggregators
+
+Static aggregators describe the static perspectives: `system-type` and/or `system-version`.
+
+- If both static and dynamic perspectives are described, they MUST only pick the static perspectives (`system-type` or `system-version`).
+- If only `system-instance` (or unspecified) perspective is available, we assume this is a generic system instance which is meant to describe all system instances as a subsidiary.
+- Static perspective resolution SHOULD follow the algorithm described [below](#static-perspective-resolution).
+
+#### Dynamic Aggregators
+
+If the aggregator supports both static and dynamic perspectives:
+
+- The ORD aggregator MUST be able to aggregate and store all perspectives (`system-type`, `system-version`, and `system-instance`) at the same time.
+- In its ORD Discovery API for consumers, it needs to implement the inheritance / fallback behavior:
+  - When `system-instance` is requested but not available, fall back to `system-version`.
+  - Static perspective resolution (when `system-type` or `system-version` is requested) SHOULD follow the algorithm described [below](#static-perspective-resolution).
 
 #### Static Perspective Resolution
 
@@ -121,30 +146,7 @@ When a consumer requests static metadata (i.e. `system-type` or `system-version`
 
 This resolution ensures that consumers can always retrieve a meaningful static description of a system type without having to know its versioning scheme or whether the provider chose `system-type` vs. `system-version`.
 
-#### Static Aggregators
+#### Tombstone Handling across Versions
 
-Static aggregators describe the static perspectives: `system-type` and/or `system-version`.
-
-- If both static and dynamic perspectives are described, they MUST only pick the static perspectives (`system-type` or `system-version`).
-- If only `system-instance` (or unspecified) perspective is available, we assume this is a generic system instance which is meant to describe all system instances as a subsidiary.
-- Static perspective resolution SHOULD follow the algorithm described [above](#static-perspective-resolution).
-
-#### Dynamic Aggregators
-
-If the aggregator supports both static and dynamic perspectives:
-
-- The ORD aggregator must be able to aggregate and store all perspectives (`system-type`, `system-version`, and `system-instance`) at the same time.
-- In its ORD Discovery API for consumers, it needs to implement the inheritance / fallback behavior:
-  - When `system-instance` is requested but not available, fall back to `system-version`.
-  - Static perspective resolution (when `system-type` or `system-version` is requested) SHOULD follow the algorithm described [above](#static-perspective-resolution).
-
-If the `system-version` perspective is used, the described version MUST be provided via the ORD `describedSystemVersion`.`version` property.
-For the `system-type` perspective, the version property is NOT required as this perspective is version-independent.
-Ideally, ORD providers SHOULD define the `describedSystemVersion`.`version` property on both the `system-version` and `system-instance` perspectives.
-
-The `version` becomes effectively the "join" criteria for how the dynamic metadata is associated to the version-specific static metadata.
-
-Some additional considerations that need to be looked into:
-
-- An older version of an application / service can have a resource which has been decommissioned (via a `Tombstone`) in a newer version.
-  - The inheritance / fallback logic MUST not fall back to the now removed resource.
+An older version of an application / service can have a resource which has been decommissioned (via a `Tombstone`) in a newer version.
+The inheritance / fallback logic MUST not fall back to the now removed resource.

--- a/docs/spec-v1/concepts/perspectives.md
+++ b/docs/spec-v1/concepts/perspectives.md
@@ -83,14 +83,13 @@ This is depicted in the following diagram:
 The `system-instance` perspective is the most specific, because a consumer could ask how a particular system instance / tenant really looks like. If there is system-instance metadata for it, we can return it directly.
 If we don't have it, we need to fall back to the `system-version` layer and instead return the metadata for the version of the system instance.
 
-If we don't know the version of a system, we can introduce a "virtual" `system-type` perspective that doesn't have to be explicitly published.
-The aggregator can treat the latest `system-version` as the `system-type` perspective and return it to represent the system type overall.
+If no explicit `system-type` perspective has been published, the aggregator SHOULD derive it from the latest `system-version` perspective (see [Static Perspective Resolution](#static-perspective-resolution) below).
 
-A consumer can legitimately be interested in all three levels, but he needs to provide a different context for each:
+A consumer can legitimately be interested in all three levels, but needs to provide a different context for each:
 
-- If `system-instance` metadata is requested, the tenant / system instance ID needs to be specified
+- If `system-instance` metadata is requested, the tenant / system instance ID needs to be specified.
 - If `system-version` metadata is requested, the system type and system version must be specified.
-- If `system-type` metadata is requested, only the system type must be specified and the latest system version is returned.
+- If `system-type` metadata is requested, only the system type must be specified. The aggregator resolves what to return (see [Static Perspective Resolution](#static-perspective-resolution)).
 
 ### Relation to System-Instance-Aware
 
@@ -112,13 +111,23 @@ If the system has dynamic metadata, it should describe both perspectives complet
 
 ## ORD Aggregator Considerations
 
+#### Static Perspective Resolution
+
+When a consumer requests static metadata (i.e. `system-type` or `system-version` perspective) for a given system type, the aggregator SHOULD resolve what to return as follows:
+
+1. If a **specific system version is requested**, return the `system-version` perspective data for that version.
+2. If **no specific version is requested**, return the explicitly provided `system-type` perspective data, if available. The `system-type` perspective takes precedence because it is explicitly maintained and version-independent.
+3. If **no specific version is requested** and **no explicit `system-type` perspective is available**, the aggregator SHOULD derive the `system-type` representation from the **latest `system-version`** perspective.
+
+This resolution ensures that consumers can always retrieve a meaningful static description of a system type without having to know its versioning scheme or whether the provider chose `system-type` vs. `system-version`.
+
 #### Static Aggregators
 
 Static aggregators describe the static perspectives: `system-type` and/or `system-version`.
 
-- If both static and dynamic perspectives are described, it MUST only pick the static perspectives (`system-type` or `system-version`)
-- If only `system-instance` (or unspecified) perspective is available, we assume this is a generic system instance which is meant to describe all system instances as a subsidiary
-- When aggregating `system-type` perspective, the aggregator MAY derive it from the latest `system-version` if not explicitly provided
+- If both static and dynamic perspectives are described, they MUST only pick the static perspectives (`system-type` or `system-version`).
+- If only `system-instance` (or unspecified) perspective is available, we assume this is a generic system instance which is meant to describe all system instances as a subsidiary.
+- Static perspective resolution SHOULD follow the algorithm described [above](#static-perspective-resolution).
 
 #### Dynamic Aggregators
 
@@ -126,9 +135,8 @@ If the aggregator supports both static and dynamic perspectives:
 
 - The ORD aggregator must be able to aggregate and store all perspectives (`system-type`, `system-version`, and `system-instance`) at the same time.
 - In its ORD Discovery API for consumers, it needs to implement the inheritance / fallback behavior:
-  - When `system-instance` is requested but not available, fall back to `system-version`
-  - When `system-version` is requested but not available (or version is unknown), fall back to `system-type`
-  - The aggregator MAY derive `system-type` from the latest `system-version` if not explicitly provided
+  - When `system-instance` is requested but not available, fall back to `system-version`.
+  - Static perspective resolution (when `system-type` or `system-version` is requested) SHOULD follow the algorithm described [above](#static-perspective-resolution).
 
 If the `system-version` perspective is used, the described version MUST be provided via the ORD `describedSystemVersion`.`version` property.
 For the `system-type` perspective, the version property is NOT required as this perspective is version-independent.

--- a/docs/spec-v1/concepts/perspectives.md
+++ b/docs/spec-v1/concepts/perspectives.md
@@ -102,7 +102,7 @@ The `perspectives` attribute deprecates the `systemInstanceAware` attribute.
 With `systemInstanceAware` it was already possible to define whether metadata was dynamic (different per system instance) or not.
 But the concept did not allow to describe the same resource in different perspectives and also did not define how the perspectives build upon each other.
 
-To migrate: replace `systemInstanceAware: true` with `perspective: "system-instance"` and split your ORD document so that static and dynamic metadata are in separate documents with their respective perspective set. See the [ORD Configuration interface](../../spec-v1/interfaces/Configuration.md#ord-v1-document-description_perspective) for the `perspective` property details.
+To migrate: replace `systemInstanceAware: true` with `perspective: "system-instance"` and split your ORD document so that static and dynamic metadata are in separate documents with their respective perspective set. See the [`perspective` property on the ORD Configuration](../../spec-v1/interfaces/Configuration.md) interface for details.
 
 ## ORD Provider Considerations
 

--- a/docs/spec-v1/index.md
+++ b/docs/spec-v1/index.md
@@ -98,13 +98,14 @@ There are [aggregation rules](#aggregation-rules) and [validation rules](#valida
 
 It MUST support all [ORD transport modes](#ord-transport-modes) that are used by the systems it aggregates.
 
+When serving static perspective requests (`system-type` or `system-version`), the aggregator SHOULD follow the [static perspective resolution](./concepts/perspectives.md#static-perspective-resolution) algorithm.
+
 In case of an ORD aggregator that supports the [dynamic perspective](#dynamic-perspective):
 
 - the aggregator MUST support [system-instance-aware](#system-instance-aware) information and MAY support further [system instance](#system-instance) grouping concepts, such as accounts etc.
 - If it needs to reflect system-instance-aware information it MUST be system-instance-aware itself.
 - In the ORD Discovery API for accessing `system-instance` perspective information, the aggregator MUST implement a fallback to the static perspective.
   - Concretely: If an ORD Provider describes an ORD resource only via perspective: `system-version` and not via `system-instance`, the aggregator still needs to return the static ORD resource description, even when the request was to learn about the state of a specific system instance. The reason is that the ORD Discovery consumer should not need to understand whether the information is currently static or system-instance-aware. Consumers should also not have to consult two APIs and ask for both the static and dynamic perspective and be forced to merge both together.
-- When serving static perspective requests (`system-type` or `system-version`), the aggregator SHOULD follow the [static perspective resolution](./concepts/perspectives.md#static-perspective-resolution) algorithm.
 - See chapter on [perspectives](#perspectives) and the [perspectives concept page](./concepts/perspectives.md) for details.
 - It SHOULD support the proposed optimizations for the transport modes, e.g. make use of `perspectives` (replaces deprecated `systemInstanceAware`), `lastUpdate` properties and support the proposed HTTP cache mechanisms. This has the potential to significantly reduce overall TCO.
 

--- a/docs/spec-v1/index.md
+++ b/docs/spec-v1/index.md
@@ -104,7 +104,8 @@ In case of an ORD aggregator that supports the [dynamic perspective](#dynamic-pe
 - If it needs to reflect system-instance-aware information it MUST be system-instance-aware itself.
 - In the ORD Discovery API for accessing `system-instance` perspective information, the aggregator MUST implement a fallback to the static perspective.
   - Concretely: If an ORD Provider describes an ORD resource only via perspective: `system-version` and not via `system-instance`, the aggregator still needs to return the static ORD resource description, even when the request was to learn about the state of a specific system instance. The reason is that the ORD Discovery consumer should not need to understand whether the information is currently static or system-instance-aware. Consumers should also not have to consult two APIs and ask for both the static and dynamic perspective and be forced to merge both together.
-  - See chapter on [perspectives](#perspectives).
+- When serving static perspective requests (`system-type` or `system-version`), the aggregator SHOULD follow the [static perspective resolution](./concepts/perspectives.md#static-perspective-resolution) algorithm.
+- See chapter on [perspectives](#perspectives) and the [perspectives concept page](./concepts/perspectives.md) for details.
 - It SHOULD support the proposed optimizations for the transport modes, e.g. make use of `perspectives` (replaces deprecated `systemInstanceAware`), `lastUpdate` properties and support the proposed HTTP cache mechanisms. This has the potential to significantly reduce overall TCO.
 
 ![ORD Aggregator Role](/img/ord-role-aggregator.svg "ORD Aggregator Role")
@@ -611,6 +612,8 @@ There is a `perspective` attribute, which allows setting the following values:
   - They SHOULD also provide a complete static perspective (`system-type` or `system-version`) if possible, as static metadata is equally useful.
 - If both perspectives are provided, each MUST be described completely, until we introduce a more optimized `system-instance-delta` perspective.
 - Content that is independent of systems (like Taxonomies, Products, Vendors) SHOULD use the `system-independent` perspective.
+
+> ⏩ For how aggregators resolve static perspective requests (e.g. which data to return when no version is specified), see the [static perspective resolution](./concepts/perspectives.md#static-perspective-resolution) algorithm on the perspectives concept page.
 
 ## ID Concepts
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -254,6 +254,7 @@
 			"integrity": "sha512-G9I2atg1ShtFp0t7zwleP6aPS4DcZvsV4uoQOripp16aR6VJzbEnKFPLW4OFXzX7avgZSpYeBAS+Zx4FOgmpPw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@algolia/client-common": "5.41.0",
 				"@algolia/requester-browser-xhr": "5.41.0",
@@ -431,6 +432,7 @@
 			"integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.5",
@@ -2570,6 +2572,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -2593,6 +2596,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2707,6 +2711,7 @@
 			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -3144,6 +3149,7 @@
 			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -4079,6 +4085,7 @@
 			"integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@docusaurus/core": "3.9.2",
 				"@docusaurus/logger": "3.9.2",
@@ -4358,6 +4365,7 @@
 			"integrity": "sha512-6c4DAbR6n6nPbnZhY2V3tzpnKnGL+6aOsLvFL26VRqhlczli9eWG0VDUNoCQEPnGwDMhPS42UhSAnz5pThm5Ag==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@docusaurus/mdx-loader": "3.9.2",
 				"@docusaurus/module-type-aliases": "3.9.2",
@@ -5083,6 +5091,7 @@
 			"integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/mdx": "^2.0.0"
 			},
@@ -5757,6 +5766,7 @@
 			"integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.21.3",
 				"@svgr/babel-preset": "8.1.0",
@@ -6483,6 +6493,7 @@
 			"integrity": "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
@@ -6524,6 +6535,7 @@
 			"integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"csstype": "^3.0.2"
 			}
@@ -6933,6 +6945,7 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -7025,6 +7038,7 @@
 			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -7073,6 +7087,7 @@
 			"integrity": "sha512-9E4b3rJmYbBkn7e3aAPt1as+VVnRhsR4qwRRgOzpeyz4PAOuwKh0HI4AN6mTrqK0S0M9fCCSTOUnuJ8gPY/tvA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@algolia/abtesting": "1.7.0",
 				"@algolia/client-abtesting": "5.41.0",
@@ -7753,6 +7768,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.19",
 				"caniuse-lite": "^1.0.30001751",
@@ -8142,6 +8158,7 @@
 			"integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@chevrotain/cst-dts-gen": "11.0.3",
 				"@chevrotain/gast": "11.0.3",
@@ -8987,6 +9004,7 @@
 			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -9323,6 +9341,7 @@
 			"integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10"
 			}
@@ -9767,6 +9786,7 @@
 			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -11183,6 +11203,7 @@
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -16744,6 +16765,7 @@
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -17403,6 +17425,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -18354,6 +18377,7 @@
 			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -19322,6 +19346,7 @@
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -19335,6 +19360,7 @@
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -19396,6 +19422,7 @@
 			"integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/react": "*"
 			},
@@ -19426,6 +19453,7 @@
 			"integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.12.13",
 				"history": "^4.9.0",
@@ -21451,6 +21479,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -21633,7 +21662,8 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"dev": true,
-			"license": "0BSD"
+			"license": "0BSD",
+			"peer": true
 		},
 		"node_modules/tslog": {
 			"version": "4.9.3",
@@ -22199,6 +22229,7 @@
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -22495,6 +22526,7 @@
 			"integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -23233,6 +23265,7 @@
 			"integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/spec/v1/Configuration.schema.yaml
+++ b/spec/v1/Configuration.schema.yaml
@@ -122,7 +122,7 @@ definitions:
               If chosen, `describedSystemVersion`.`version` MUST be provided, too.
 
               This perspective describes how a system of a particular type and version generally look like.
-              The latest system-version MAY also be interpreted as the [system-type](../index.md#system-type) perspective.
+              If no explicit `system-type` perspective is available, the latest system-version SHOULD be interpreted as the [system-type](../index.md#system-type) perspective (see [static perspective resolution](../concepts/perspectives#static-perspective-resolution)).
           - const: "system-instance"
             description: |-
               Describes the complete dynamic [system-instance](../index.md#system-instance) (tenant) perspective as known at run-time.

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -100,7 +100,7 @@ properties:
           If chosen, `describedSystemVersion`.`version` MUST be provided, too.
 
           This perspective describes how a system of a particular type and version generally look like.
-          The latest system-version MAY also be interpreted as the [system-type](../index.md#system-type) perspective.
+          If no explicit `system-type` perspective is available, the latest system-version SHOULD be interpreted as the [system-type](../index.md#system-type) perspective (see [static perspective resolution](../concepts/perspectives#static-perspective-resolution)).
       - const: "system-instance"
         description: |-
           Describes the complete dynamic [system-instance](../index.md#system-instance) (tenant) perspective as known at run-time.


### PR DESCRIPTION
- Clarification: Consolidated and clarified the [static perspective resolution](https://open-resource-discovery.org/spec-v1/concepts/perspectives#static-perspective-resolution) algorithm for aggregators. When no specific version is requested, explicit `system-type` perspective data takes precedence; if unavailable, the aggregator SHOULD derive it from the latest `system-version`. Previously this behavior was scattered and only stated as MAY.