### PR TITLE
Remove model extensions index page as we didn't use the concept now

### DIFF
--- a/docs/spec-extensions/index.md
+++ b/docs/spec-extensions/index.md
@@ -15,6 +15,5 @@ Most notably, you'll find:
 - [Registered **Access Strategies**](/spec-extensions/access-strategies/) that standardize how ORD information can be accessed by the ORD Aggregators.
 - [Registered **Policy Levels**](/spec-extensions/policy-levels/) that standardize (ideally verifiable) rules how ORD should be implemented by ORD Providers.
 - [Registered **Global Group Types**](/spec-extensions/group-types/) for globally aligned and pre-defined group types (and potentially also predefined group instances).
-{/* - [**Model Extensions**](/spec-extensions/models/) that provide additional model schemas for specific use cases. */}
 
 Specification Extensions have registered [Specification IDs](../spec-v1/index.md#specification-id).

--- a/src/helper/copyGeneratedToDestination.ts
+++ b/src/helper/copyGeneratedToDestination.ts
@@ -1,5 +1,4 @@
 import fs from "fs-extra";
-import path from "node:path";
 import { log } from "./log";
 
 export async function copyGeneratedToDestination(): Promise<void> {
@@ -22,48 +21,6 @@ export async function copyGeneratedToDestination(): Promise<void> {
 			"./src/generated/spec/v1/docs/OrdOverlay.md",
 			"docs/spec-v1/interfaces/OrdOverlay.md",
 		);
-
-		// Copy Model Extensions (any .md files in docs/ that aren't Configuration or Document)
-		await fs.ensureDir("docs/spec-extensions/models/");
-		const generatedDocsPath = "./src/generated/spec/v1/docs";
-		if (await fs.pathExists(generatedDocsPath)) {
-			const generatedDocs = await fs.readdir(generatedDocsPath);
-			const modelExtensionDocs = generatedDocs.filter(
-				(file) =>
-					file.endsWith(".md") &&
-					file !== "Configuration.md" &&
-					file !== "Document.md" &&
-					file !== "OrdOverlay.md",
-			);
-			for (const doc of modelExtensionDocs) {
-				await fs.copy(
-					path.join(generatedDocsPath, doc),
-					path.join("docs/spec-extensions/models", doc),
-				);
-				log.info(`Copied model extension doc: ${doc}`);
-			}
-		}
-
-		// Copy Model Extension schemas to their canonical $id URL path
-		await fs.ensureDir("static/spec-extension/models/");
-		const generatedSchemasPath = "./src/generated/spec/v1/schemas";
-		if (await fs.pathExists(generatedSchemasPath)) {
-			const generatedSchemas = await fs.readdir(generatedSchemasPath);
-			const modelExtensionSchemas = generatedSchemas.filter(
-				(file) =>
-					file.endsWith(".schema.json") &&
-					file !== "Configuration.schema.json" &&
-					file !== "Document.schema.json" &&
-					file !== "OrdOverlay.schema.json",
-			);
-			for (const schema of modelExtensionSchemas) {
-				await fs.copy(
-					path.join(generatedSchemasPath, schema),
-					path.join("static/spec-extension/models", schema),
-				);
-				log.info(`Copied model extension schema: ${schema}`);
-			}
-		}
 
 		// Create docs/spec-v1/examples/ directory and copy examples specifically
 		await fs.ensureDir("docs/spec-v1/examples/");

--- a/src/validation/exampleValidation.test.ts
+++ b/src/validation/exampleValidation.test.ts
@@ -31,49 +31,7 @@ const schemaMappings: SchemaMapping[] = [
 		examplesPath: "./examples/documents",
 		filePattern: /\.json$/,
 	},
-	// Model extensions will be automatically added here when they exist
-	// by scanning spec-extension/models/ directory
 ];
-
-/**
- * Dynamically discover model extension schemas and their examples
- */
-async function discoverModelExtensionSchemas(): Promise<SchemaMapping[]> {
-	const modelExtensions: SchemaMapping[] = [];
-	const schemasDir = "./src/generated/spec/v1/schemas";
-
-	try {
-		const files = await fs.readdir(schemasDir);
-		for (const file of files) {
-			// Look for schema files that aren't Configuration or Document
-			if (
-				file.endsWith(".schema.json") &&
-				file !== "Configuration.schema.json" &&
-				file !== "Document.schema.json"
-			) {
-				const schemaName = file.replace(".schema.json", "");
-				const examplesPath = `./examples/models/${schemaName.toLowerCase()}`;
-
-				// Check if examples directory exists
-				try {
-					await fs.access(examplesPath);
-					modelExtensions.push({
-						schemaName,
-						schemaPath: path.join(schemasDir, file),
-						examplesPath,
-						filePattern: /\.json$/,
-					});
-				} catch {
-					// Examples directory doesn't exist yet, skip
-				}
-			}
-		}
-	} catch {
-		// Generated schemas directory doesn't exist yet
-	}
-
-	return modelExtensions;
-}
 
 /**
  * Read and parse a JSON file
@@ -118,14 +76,8 @@ function createValidator() {
  * Main test suite
  */
 describe("Example Validation", async () => {
-	// Discover all schema mappings including model extensions
-	const allMappings = [
-		...schemaMappings,
-		...(await discoverModelExtensionSchemas()),
-	];
-
 	// Create a test suite for each schema
-	for (const mapping of allMappings) {
+	for (const mapping of schemaMappings) {
 		await describe(`${mapping.schemaName} Examples`, async () => {
 			// Load schema
 			let schema: unknown;
@@ -193,7 +145,7 @@ describe("Example Validation", async () => {
 
 	// Additional test: verify all examples have $schema property pointing to correct URL
 	await describe("Schema References", async () => {
-		for (const mapping of allMappings) {
+		for (const mapping of schemaMappings) {
 			const exampleFiles = await getExampleFiles(
 				mapping.examplesPath,
 				mapping.filePattern,


### PR DESCRIPTION
Now that ORD Overlays (#86 ) is not a model extension but regular ORD interface, we don't need this. Let's clean it up. 