### PR TITLE
Add ord:ai-hint predefined label key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ### Added
 
-- Added `ord:ai-hint` as a pre-defined label key on all ORD resources for guidance targeted at AI consumers (LLMs, orchestrators), kept intentionally separate from human-readable description fields. MUST contain exactly one value; SHOULD be CommonMark Markdown. Inheritable from `Package`. See [AI Agents and Protocols](./docs/spec-v1/concepts/ai-agents-and-protocols.md).
+- Added `ord:ai-hint` as a pre-defined label key on all ORD resources for guidance targeted at AI consumers (LLMs, orchestrators), kept intentionally separate from human-readable description fields. MUST contain exactly one value; SHOULD be CommonMark Markdown. See [AI Agents and Protocols](https://open-resource-discovery.org/spec-v1/concepts/ai-agents-and-protocols).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+### Added
+
+- Added `ord:ai-hint` as a pre-defined label key on all ORD resources for guidance targeted at AI consumers (LLMs, orchestrators), kept intentionally separate from human-readable description fields. MUST contain exactly one value; SHOULD be CommonMark Markdown. Inheritable from `Package`. See [AI Agents and Protocols](./docs/spec-v1/concepts/ai-agents-and-protocols.md).
+
 ### Changed
 
-- Clarified the resource definition uniqueness rule: `customType` (for `type: "custom"`) is now explicitly part of the composite key alongside `type`, `purpose`, and `visibility`; the `purpose` field description cross-references this constraint.
+- Clarified the resource definition uniqueness rule: `customType` (for `type: "custom"`) is explicitly part of the composite key alongside `type`, `purpose`, and `visibility`; the `purpose` field description cross-references this constraint.
 - Aligned ORD Overlay docs to the general resource definition uniqueness rule: the combination of `purpose` and `visibility` MUST be unique across overlay entries (`type: "ord:overlay:v1"`) on the same resource (was SHOULD — the MUST was already stated in the schema, so this is a documentation fix, not a stricter requirement).
 
 ## [1.15.0]

--- a/docs/spec-v1/concepts/ai-agents-and-protocols.md
+++ b/docs/spec-v1/concepts/ai-agents-and-protocols.md
@@ -229,7 +229,6 @@ Human-readable documentation (`description`, `shortDescription`) is written for 
 
 - **Exactly one value**: The array MUST contain exactly one string. (Labels normally allow multiple values, but `ord:ai-hint` is constrained to a single entry so consumers always receive one coherent text.)
 - **Markdown recommended**: The value SHOULD be written in [CommonMark](https://spec.commonmark.org/) Markdown, but any plain text is accepted.
-- **Inheritance from Package**: Because `ord:ai-hint` is a regular label, it is inherited by all resources inside a `Package` — a convenient way to set a landscape-wide or package-wide hint that applies unless overridden on individual resources.
 
 ## Use Cases
 

--- a/docs/spec-v1/concepts/ai-agents-and-protocols.md
+++ b/docs/spec-v1/concepts/ai-agents-and-protocols.md
@@ -200,6 +200,37 @@ Here's an example of an Integration Dependency for an agent:
 }
 ```
 
+## AI Hints on ORD Resources
+
+Any ORD resource (APIs, Events, Agents, Entity Types, Data Products, etc.) can carry an `ord:ai-hint` label — a pre-defined, ORD-standardized label key that provides guidance specifically for AI consumers such as LLMs and agent orchestrators.
+
+```json
+{
+  "apiResources": [
+    {
+      "ordId": "sap.foo:apiResource:DisputeResolutionAgent:v1",
+      "title": "Dispute Resolution Agent",
+      "labels": {
+        "ord:ai-hint": [
+          "Use this API to **retrieve** and **manage** dispute cases. Prefer structured JSON payloads over free-text fields when invoking tools. Do not call `DELETE /cases/{id}` unless the case status is `closed`."
+        ]
+      }
+      // ...
+    }
+  ]
+}
+```
+
+### Why a Separate Field?
+
+Human-readable documentation (`description`, `shortDescription`) is written for end users and developers browsing a catalog. AI-targeted guidance has different concerns — it may include tool-use patterns, LLM-specific caveats, or instructions that would read as noise in standard docs. Keeping these separate lets both evolve independently.
+
+### Constraints
+
+- **Exactly one value**: The array MUST contain exactly one string. (Labels normally allow multiple values, but `ord:ai-hint` is constrained to a single entry so consumers always receive one coherent text.)
+- **Markdown recommended**: The value SHOULD be written in [CommonMark](https://spec.commonmark.org/) Markdown, but any plain text is accepted.
+- **Inheritance from Package**: Because `ord:ai-hint` is a regular label, it is inherited by all resources inside a `Package` — a convenient way to set a landscape-wide or package-wide hint that applies unless overridden on individual resources.
+
 ## Use Cases
 
 Describing agents in ORD enables several key scenarios:

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -4579,7 +4579,25 @@ definitions:
 
       **RECOMMENDATION**: Use a [Concept ID](../index.md#concept-id) as the label key to indicate ownership and avoid naming conflicts.
       The namespace in the Concept ID clearly identifies who owns and defines the label's semantics.
+
+      ### Pre-defined Label Keys
+
+      The `ord` namespace reserves the following label keys for standardized use:
+
+      - `ord:ai-hint`: Provides a hint for AI consumers (e.g., LLMs) on how to use or interpret the ORD resource. Intentionally kept separate from human-readable description fields so that end-user-facing documentation and AI-targeted guidance can evolve independently. MUST contain exactly one value. The value SHOULD be in [CommonMark](https://spec.commonmark.org/) (Markdown) format.
     x-ums-type: "custom"
+    properties:
+      "ord:ai-hint":
+        type: array
+        description: |-
+          Provides a hint for AI consumers (e.g., LLMs) on how to use or interpret the ORD resource.
+          Intentionally kept separate from human-readable description fields so that end-user-facing documentation
+          and AI-targeted guidance can evolve independently.
+          MUST contain exactly one value. The value SHOULD be in CommonMark (Markdown) format.
+        maxItems: 1
+        items:
+          type: string
+          minLength: 1
     patternProperties:
       "^[a-zA-Z0-9-_.:\/]*$":
         type: array
@@ -4589,6 +4607,7 @@ definitions:
     examples:
       - foo.bar:labelKeyName: ["value"]
       - foo.bar:cost-center: ["CC-12345", "CC-67890"]
+      - ord:ai-hint: ["Use this API to **retrieve** and **manage** dispute cases. Prefer structured JSON payloads over free-text fields when invoking tools."]
 
   ############################################################################################################
 

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -4579,13 +4579,13 @@ definitions:
 
       **RECOMMENDATION**: Use a [Concept ID](../index.md#concept-id) as the label key to indicate ownership and avoid naming conflicts.
       The namespace in the Concept ID clearly identifies who owns and defines the label's semantics.
-
-      ### Pre-defined Label Keys
-
-      The `ord` namespace reserves the following label keys for standardized use:
-
-      - `ord:ai-hint`: Provides a hint for AI consumers (e.g., LLMs) on how to use or interpret the ORD resource. Intentionally kept separate from human-readable description fields so that end-user-facing documentation and AI-targeted guidance can evolve independently. MUST contain exactly one value. The value SHOULD be in [CommonMark](https://spec.commonmark.org/) (Markdown) format.
     x-ums-type: "custom"
+    patternProperties:
+      "^[a-zA-Z0-9-_.:\/]*$":
+        type: array
+        items:
+          type: string
+          minLength: 1
     properties:
       "ord:ai-hint":
         type: array
@@ -4595,12 +4595,6 @@ definitions:
           and AI-targeted guidance can evolve independently.
           MUST contain exactly one value. The value SHOULD be in CommonMark (Markdown) format.
         maxItems: 1
-        items:
-          type: string
-          minLength: 1
-    patternProperties:
-      "^[a-zA-Z0-9-_.:\/]*$":
-        type: array
         items:
           type: string
           minLength: 1

--- a/src/generated/spec/v1/types/Document.ts
+++ b/src/generated/spec/v1/types/Document.ts
@@ -209,8 +209,23 @@ export interface SystemType {
  *
  * **RECOMMENDATION**: Use a [Concept ID](../index.md#concept-id) as the label key to indicate ownership and avoid naming conflicts.
  * The namespace in the Concept ID clearly identifies who owns and defines the label's semantics.
+ *
+ * ### Pre-defined Label Keys
+ *
+ * The `ord` namespace reserves the following label keys for standardized use:
+ *
+ * - `ord:ai-hint`: Provides a hint for AI consumers (e.g., LLMs) on how to use or interpret the ORD resource. Intentionally kept separate from human-readable description fields so that end-user-facing documentation and AI-targeted guidance can evolve independently. MUST contain exactly one value. The value SHOULD be in [CommonMark](https://spec.commonmark.org/) (Markdown) format.
  */
 export interface Labels {
+  /**
+   * Provides a hint for AI consumers (e.g., LLMs) on how to use or interpret the ORD resource.
+   * Intentionally kept separate from human-readable description fields so that end-user-facing documentation
+   * and AI-targeted guidance can evolve independently.
+   * MUST contain exactly one value. The value SHOULD be in CommonMark (Markdown) format.
+   *
+   * @maxItems 1
+   */
+  "ord:ai-hint"?: [] | [string];
   /**
    * This interface was referenced by `Labels`'s JSON-Schema definition
    * via the `patternProperty` "^[a-zA-Z0-9-_.:/]*$".

--- a/src/generated/spec/v1/types/Document.ts
+++ b/src/generated/spec/v1/types/Document.ts
@@ -209,12 +209,6 @@ export interface SystemType {
  *
  * **RECOMMENDATION**: Use a [Concept ID](../index.md#concept-id) as the label key to indicate ownership and avoid naming conflicts.
  * The namespace in the Concept ID clearly identifies who owns and defines the label's semantics.
- *
- * ### Pre-defined Label Keys
- *
- * The `ord` namespace reserves the following label keys for standardized use:
- *
- * - `ord:ai-hint`: Provides a hint for AI consumers (e.g., LLMs) on how to use or interpret the ORD resource. Intentionally kept separate from human-readable description fields so that end-user-facing documentation and AI-targeted guidance can evolve independently. MUST contain exactly one value. The value SHOULD be in [CommonMark](https://spec.commonmark.org/) (Markdown) format.
  */
 export interface Labels {
   /**


### PR DESCRIPTION
### Added

- Added `ord:ai-hint` as a pre-defined label key on all ORD resources for guidance targeted at AI consumers (LLMs, orchestrators), kept intentionally separate from human-readable description fields. MUST contain exactly one value; SHOULD be CommonMark Markdown. 