### PR TITLE
Add AI Hint property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ### Added
 
-- Added `ord:ai-hint` as a pre-defined label key on all ORD resources for guidance targeted at AI consumers (LLMs, orchestrators), kept intentionally separate from human-readable description fields. MUST contain exactly one value; SHOULD be CommonMark Markdown. Inheritable from `Package`. See [AI Agents and Protocols](./docs/spec-v1/concepts/ai-agents-and-protocols.md).
+- Added `ord:ai-hint` as a pre-defined label key on all ORD resources for guidance targeted at AI consumers (LLMs, orchestrators), kept intentionally separate from human-readable description fields. MUST contain exactly one value; SHOULD be CommonMark Markdown. See [AI Agents and Protocols](https://open-resource-discovery.org/spec-v1/concepts/ai-agents-and-protocols).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+### Added
+
+- Added `ord:ai-hint` as a pre-defined label key on all ORD resources for guidance targeted at AI consumers (LLMs, orchestrators), kept intentionally separate from human-readable description fields. MUST contain exactly one value; SHOULD be CommonMark Markdown. Inheritable from `Package`. See [AI Agents and Protocols](./docs/spec-v1/concepts/ai-agents-and-protocols.md).
+
 ### Changed
 
-- Clarified the resource definition uniqueness rule: `customType` (for `type: "custom"`) is now explicitly part of the composite key alongside `type`, `purpose`, and `visibility`; the `purpose` field description cross-references this constraint.
+- Clarified the resource definition uniqueness rule: `customType` (for `type: "custom"`) is explicitly part of the composite key alongside `type`, `purpose`, and `visibility`; the `purpose` field description cross-references this constraint.
 - Aligned ORD Overlay docs to the general resource definition uniqueness rule: the combination of `purpose` and `visibility` MUST be unique across overlay entries (`type: "ord:overlay:v1"`) on the same resource (was SHOULD — the MUST was already stated in the schema, so this is a documentation fix, not a stricter requirement).
 
 ## [1.15.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ### Added
 
-- Added `ord:ai-hint` as a pre-defined label key on all ORD resources for guidance targeted at AI consumers (LLMs, orchestrators), kept intentionally separate from human-readable description fields. MUST contain exactly one value; SHOULD be CommonMark Markdown. See [AI Agents and Protocols](https://open-resource-discovery.org/spec-v1/concepts/ai-agents-and-protocols).
+- Added `aiHint` as a dedicated, optional property on API Resources, Event Resources, Entity Types, Data Products, Agents, and Capabilities. Provides guidance targeted at AI consumers (LLMs, orchestrators), kept intentionally separate from human-readable `description` fields so both can evolve independently. SHOULD be CommonMark Markdown. See [AI Agents and Protocols](https://open-resource-discovery.org/spec-v1/concepts/ai-agents-and-protocols#ai-hints-on-ord-resources).
 
 ### Changed
 

--- a/docs/spec-v1/concepts/ai-agents-and-protocols.md
+++ b/docs/spec-v1/concepts/ai-agents-and-protocols.md
@@ -229,7 +229,6 @@ Human-readable documentation (`description`, `shortDescription`) is written for 
 
 - **Exactly one value**: The array MUST contain exactly one string. (Labels normally allow multiple values, but `ord:ai-hint` is constrained to a single entry so consumers always receive one coherent text.)
 - **Markdown recommended**: The value SHOULD be written in [CommonMark](https://spec.commonmark.org/) Markdown, but any plain text is accepted.
-- **Inheritance from Package**: Because `ord:ai-hint` is a regular label, it is inherited by all resources inside a `Package` — a convenient way to set a landscape-wide or package-wide hint that applies unless overridden on individual resources.
 
 ## Use Cases
 

--- a/docs/spec-v1/concepts/ai-agents-and-protocols.md
+++ b/docs/spec-v1/concepts/ai-agents-and-protocols.md
@@ -200,6 +200,37 @@ Here's an example of an Integration Dependency for an agent:
 }
 ```
 
+## AI Hints on ORD Resources
+
+Any ORD resource (APIs, Events, Agents, Entity Types, Data Products, etc.) can carry an `ord:ai-hint` label — a pre-defined, ORD-standardized label key that provides guidance specifically for AI consumers such as LLMs and agent orchestrators.
+
+```json
+{
+  "apiResources": [
+    {
+      "ordId": "sap.foo:apiResource:DisputeResolutionAgent:v1",
+      "title": "Dispute Resolution Agent",
+      "labels": {
+        "ord:ai-hint": [
+          "Use this API to **retrieve** and **manage** dispute cases. Prefer structured JSON payloads over free-text fields when invoking tools. Do not call `DELETE /cases/{id}` unless the case status is `closed`."
+        ]
+      }
+      // ...
+    }
+  ]
+}
+```
+
+### Why a Separate Field?
+
+Human-readable documentation (`description`, `shortDescription`) is written for end users and developers browsing a catalog. AI-targeted guidance has different concerns — it may include tool-use patterns, LLM-specific caveats, or instructions that would read as noise in standard docs. Keeping these separate lets both evolve independently.
+
+### Constraints
+
+- **Exactly one value**: The array MUST contain exactly one string. (Labels normally allow multiple values, but `ord:ai-hint` is constrained to a single entry so consumers always receive one coherent text.)
+- **Markdown recommended**: The value SHOULD be written in [CommonMark](https://spec.commonmark.org/) Markdown, but any plain text is accepted.
+- **Inheritance from Package**: Because `ord:ai-hint` is a regular label, it is inherited by all resources inside a `Package` — a convenient way to set a landscape-wide or package-wide hint that applies unless overridden on individual resources.
+
 ## Use Cases
 
 Describing agents in ORD enables several key scenarios:

--- a/docs/spec-v1/concepts/ai-agents-and-protocols.md
+++ b/docs/spec-v1/concepts/ai-agents-and-protocols.md
@@ -210,7 +210,9 @@ Without `subset`, the dependency would imply access to all operations of the ref
 
 ## AI Hints on ORD Resources
 
-Any ORD resource (APIs, Events, Agents, Entity Types, Data Products, etc.) can carry an `ord:ai-hint` label — a pre-defined, ORD-standardized label key that provides guidance specifically for AI consumers such as LLMs and agent orchestrators.
+The following ORD resource types support an `aiHint` property: API Resources, Event Resources, Entity Types, Data Products, Agents, and Capabilities.
+
+`aiHint` provides guidance specifically for AI consumers such as LLMs and agent orchestrators, and is intentionally separate from human-facing `description` and `shortDescription` fields so both can evolve independently.
 
 ```json
 {
@@ -218,12 +220,8 @@ Any ORD resource (APIs, Events, Agents, Entity Types, Data Products, etc.) can c
     {
       "ordId": "sap.foo:apiResource:DisputeResolutionAgent:v1",
       "title": "Dispute Resolution Agent",
-      "labels": {
-        "ord:ai-hint": [
-          "Use this API to **retrieve** and **manage** dispute cases. Prefer structured JSON payloads over free-text fields when invoking tools. Do not call `DELETE /cases/{id}` unless the case status is `closed`."
-        ]
-      }
-      // ...
+      "description": "Manages dispute cases in the system.",
+      "aiHint": "Use this API to **retrieve** and **manage** dispute cases. Prefer structured JSON payloads over free-text fields when invoking tools. Do not call `DELETE /cases/{id}` unless the case status is `closed`."
     }
   ]
 }
@@ -233,10 +231,11 @@ Any ORD resource (APIs, Events, Agents, Entity Types, Data Products, etc.) can c
 
 Human-readable documentation (`description`, `shortDescription`) is written for end users and developers browsing a catalog. AI-targeted guidance has different concerns — it may include tool-use patterns, LLM-specific caveats, or instructions that would read as noise in standard docs. Keeping these separate lets both evolve independently.
 
-### Constraints
+### Best Practices
 
-- **Exactly one value**: The array MUST contain exactly one string. (Labels normally allow multiple values, but `ord:ai-hint` is constrained to a single entry so consumers always receive one coherent text.)
-- **Markdown recommended**: The value SHOULD be written in [CommonMark](https://spec.commonmark.org/) Markdown, but any plain text is accepted.
+- **Markdown recommended**: The value SHOULD be written in [CommonMark](https://spec.commonmark.org/) Markdown.
+- **Be action-oriented**: Describe *how* to use the resource (verbs, conditions, caveats), not just *what* it is — the `description` already covers that.
+- **Keep it focused**: Aim for a short, dense paragraph rather than exhaustive documentation. Link to detailed docs via the `links` property.
 
 ## Use Cases
 

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -1706,8 +1706,6 @@ definitions:
 
       aiHint:
         <<: *aiHint
-        examples:
-          - "Subscribe to this event to react when an invoice is cancelled. Filter by `companyCode` to narrow to relevant tenants."
 
       ## Assignments to groupings
 
@@ -2004,8 +2002,6 @@ definitions:
 
       aiHint:
         <<: *aiHint
-        examples:
-          - "A **BusinessPartner** can be an individual or organization. Prefer `type: Organization` for B2B contexts. Use the `roles` array to filter by supplier, customer, or bank."
 
       partOfPackage:
         <<: *partOfPackage
@@ -2206,8 +2202,6 @@ definitions:
 
       aiHint:
         <<: *aiHint
-        examples:
-          - "Use this data product to access **customer order** data. Filter by `customerId` and `orderDate` for targeted queries. Output port `customerOrderItems` provides line-item detail."
 
       ## Assignment to Bundles
 

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -4579,7 +4579,25 @@ definitions:
 
       **RECOMMENDATION**: Use a [Concept ID](../index.md#concept-id) as the label key to indicate ownership and avoid naming conflicts.
       The namespace in the Concept ID clearly identifies who owns and defines the label's semantics.
+
+      ### Pre-defined Label Keys
+
+      The `ord` namespace reserves the following label keys for standardized use:
+
+      - `ord:ai-hint`: Provides a hint for AI consumers (e.g., LLMs) on how to use or interpret the ORD resource. Intentionally kept separate from human-readable description fields so that end-user-facing documentation and AI-targeted guidance can evolve independently. MUST contain exactly one value. The value SHOULD be in [CommonMark](https://spec.commonmark.org/) (Markdown) format.
     x-ums-type: "custom"
+    properties:
+      "ord:ai-hint":
+        type: array
+        description: |-
+          Provides a hint for AI consumers (e.g., LLMs) on how to use or interpret the ORD resource.
+          Intentionally kept separate from human-readable description fields so that end-user-facing documentation
+          and AI-targeted guidance can evolve independently.
+          MUST contain exactly one value. The value SHOULD be in CommonMark (Markdown) format.
+        maxItems: 1
+        items:
+          type: string
+          minLength: 1
     patternProperties:
       "^[a-zA-Z0-9-_.:\/]*$":
         type: array
@@ -4589,6 +4607,7 @@ definitions:
     examples:
       - foo.bar:labelKeyName: ["value"]
       - foo.bar:cost-center: ["CC-12345", "CC-67890"]
+      - ord:ai-hint: ["Use this API to **retrieve** and **manage** dispute cases. Prefer structured JSON payloads over free-text fields when invoking tools."]
 
   ############################################################################################################
 

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -1712,6 +1712,7 @@ definitions:
 
       aiHint:
         <<: *aiHint
+        examples: []
 
       ## Assignments to groupings
 
@@ -2008,6 +2009,7 @@ definitions:
 
       aiHint:
         <<: *aiHint
+        examples: []
 
       partOfPackage:
         <<: *partOfPackage
@@ -3355,6 +3357,7 @@ definitions:
 
       aiHint:
         <<: *aiHint
+        examples: []
 
       partOfPackage:
         <<: *partOfPackage

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -951,6 +951,18 @@ definitions:
             read existing Request for Quotation data from the SAP S/4HANA Cloud
             or SAP S/4HANA on-Premise.
 
+      aiHint: &aiHint
+        type: string
+        minLength: 1
+        description: &aiHintText |-
+          Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.
+          Intentionally separate from human-facing `description` so both can evolve independently.
+          SHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).
+
+          For guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources).
+        examples:
+          - "Use this API to **retrieve** and **manage** dispute cases. Prefer structured JSON payloads over free-text fields when invoking tools."
+
       ## Assignments to bundling concepts
 
       partOfPackage: &partOfPackage
@@ -1692,6 +1704,11 @@ definitions:
           - |
             This event is raised by the SAP S/4HANA Cloud system when an invoice document is cancelled.
 
+      aiHint:
+        <<: *aiHint
+        examples:
+          - "Subscribe to this event to react when an invoice is cancelled. Filter by `companyCode` to narrow to relevant tenants."
+
       ## Assignments to groupings
 
       partOfPackage:
@@ -1985,6 +2002,11 @@ definitions:
           - |
             A workforce person is a natural person with a work agreement or relationship in form of a work assignment; it can be an employee or a contingent worker.
 
+      aiHint:
+        <<: *aiHint
+        examples:
+          - "A **BusinessPartner** can be an individual or organization. Prefer `type: Organization` for B2B contexts. Use the `roles` array to filter by supplier, customer, or bank."
+
       partOfPackage:
         <<: *partOfPackage
         x-ums-reverse-relationship:
@@ -2181,6 +2203,11 @@ definitions:
         description: *descriptionText
         examples:
           - The data product Customer Order offers access to all online and offline orders submitted by customers. It provides a customer view on the orders. For fulfillment-specific aspects please refer to the data product Fulfillment Order.
+
+      aiHint:
+        <<: *aiHint
+        examples:
+          - "Use this data product to access **customer order** data. Filter by `customerId` and `orderDate` for targeted queries. Output port `customerOrderItems` provides line-item detail."
 
       ## Assignment to Bundles
 
@@ -2877,6 +2904,11 @@ definitions:
         minLength: 1
         description: *descriptionText
 
+      aiHint:
+        <<: *aiHint
+        examples:
+          - "Invoke this agent to **resolve** open dispute cases. Provide the `caseId`; the agent autonomously gathers evidence, proposes resolution, and awaits approval before closing."
+
       partOfPackage:
         <<: *partOfPackage
         x-ums-reverse-relationship:
@@ -3314,6 +3346,9 @@ definitions:
         type: string
         minLength: 1
         description: *descriptionText
+
+      aiHint:
+        <<: *aiHint
 
       partOfPackage:
         <<: *partOfPackage
@@ -4594,22 +4629,9 @@ definitions:
         items:
           type: string
           minLength: 1
-    properties:
-      "ord:ai-hint":
-        type: array
-        description: |-
-          Provides a hint for AI consumers (e.g., LLMs) on how to use or interpret the ORD resource.
-          Intentionally kept separate from human-readable description fields so that end-user-facing documentation
-          and AI-targeted guidance can evolve independently.
-          MUST contain exactly one value. The value SHOULD be in CommonMark (Markdown) format.
-        maxItems: 1
-        items:
-          type: string
-          minLength: 1
     examples:
       - foo.bar:labelKeyName: ["value"]
       - foo.bar:cost-center: ["CC-12345", "CC-67890"]
-      - ord:ai-hint: ["Use this API to **retrieve** and **manage** dispute cases. Prefer structured JSON payloads over free-text fields when invoking tools."]
 
   ############################################################################################################
 

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -4579,13 +4579,13 @@ definitions:
 
       **RECOMMENDATION**: Use a [Concept ID](../index.md#concept-id) as the label key to indicate ownership and avoid naming conflicts.
       The namespace in the Concept ID clearly identifies who owns and defines the label's semantics.
-
-      ### Pre-defined Label Keys
-
-      The `ord` namespace reserves the following label keys for standardized use:
-
-      - `ord:ai-hint`: Provides a hint for AI consumers (e.g., LLMs) on how to use or interpret the ORD resource. Intentionally kept separate from human-readable description fields so that end-user-facing documentation and AI-targeted guidance can evolve independently. MUST contain exactly one value. The value SHOULD be in [CommonMark](https://spec.commonmark.org/) (Markdown) format.
     x-ums-type: "custom"
+    patternProperties:
+      "^[a-zA-Z0-9-_.:\/]*$":
+        type: array
+        items:
+          type: string
+          minLength: 1
     properties:
       "ord:ai-hint":
         type: array
@@ -4595,12 +4595,6 @@ definitions:
           and AI-targeted guidance can evolve independently.
           MUST contain exactly one value. The value SHOULD be in CommonMark (Markdown) format.
         maxItems: 1
-        items:
-          type: string
-          minLength: 1
-    patternProperties:
-      "^[a-zA-Z0-9-_.:\/]*$":
-        type: array
         items:
           type: string
           minLength: 1

--- a/src/generated/spec/v1/types/Document.ts
+++ b/src/generated/spec/v1/types/Document.ts
@@ -212,15 +212,6 @@ export interface SystemType {
  */
 export interface Labels {
   /**
-   * Provides a hint for AI consumers (e.g., LLMs) on how to use or interpret the ORD resource.
-   * Intentionally kept separate from human-readable description fields so that end-user-facing documentation
-   * and AI-targeted guidance can evolve independently.
-   * MUST contain exactly one value. The value SHOULD be in CommonMark (Markdown) format.
-   *
-   * @maxItems 1
-   */
-  "ord:ai-hint"?: [] | [string];
-  /**
    * This interface was referenced by `Labels`'s JSON-Schema definition
    * via the `patternProperty` "^[a-zA-Z0-9-_.:/]*$".
    */
@@ -389,6 +380,14 @@ export interface ApiResource {
    * Detailed documentation SHOULD be attached as (typed) links.
    */
   description: string;
+  /**
+   * Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.
+   * Intentionally separate from human-facing `description` so both can evolve independently.
+   * SHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * For guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources).
+   */
+  aiHint?: string;
   /**
    * Defines which Package the resource is part of.
    *
@@ -1328,6 +1327,14 @@ export interface EventResource {
    */
   description: string;
   /**
+   * Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.
+   * Intentionally separate from human-facing `description` so both can evolve independently.
+   * SHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * For guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources).
+   */
+  aiHint?: string;
+  /**
    * Defines which Package the resource is part of.
    *
    * MUST be a valid reference to a [Package](#package) ORD ID.
@@ -1858,6 +1865,14 @@ export interface EntityType {
    */
   description?: string;
   /**
+   * Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.
+   * Intentionally separate from human-facing `description` so both can evolve independently.
+   * SHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * For guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources).
+   */
+  aiHint?: string;
+  /**
    * Defines which Package the resource is part of.
    *
    * MUST be a valid reference to a [Package](#package) ORD ID.
@@ -2124,6 +2139,14 @@ export interface Capability {
    * Detailed documentation SHOULD be attached as (typed) links.
    */
   description?: string;
+  /**
+   * Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.
+   * Intentionally separate from human-facing `description` so both can evolve independently.
+   * SHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * For guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources).
+   */
+  aiHint?: string;
   /**
    * Defines which Package the resource is part of.
    *
@@ -2423,6 +2446,14 @@ export interface DataProduct {
    * Detailed documentation SHOULD be attached as (typed) links.
    */
   description: string;
+  /**
+   * Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.
+   * Intentionally separate from human-facing `description` so both can evolve independently.
+   * SHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * For guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources).
+   */
+  aiHint?: string;
   /**
    * Defines which Package the resource is part of.
    *
@@ -2848,6 +2879,14 @@ export interface Agent {
    * Detailed documentation SHOULD be attached as (typed) links.
    */
   description?: string;
+  /**
+   * Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.
+   * Intentionally separate from human-facing `description` so both can evolve independently.
+   * SHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * For guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources).
+   */
+  aiHint?: string;
   /**
    * Defines which Package the resource is part of.
    *

--- a/src/generated/spec/v1/types/Document.ts
+++ b/src/generated/spec/v1/types/Document.ts
@@ -209,8 +209,23 @@ export interface SystemType {
  *
  * **RECOMMENDATION**: Use a [Concept ID](../index.md#concept-id) as the label key to indicate ownership and avoid naming conflicts.
  * The namespace in the Concept ID clearly identifies who owns and defines the label's semantics.
+ *
+ * ### Pre-defined Label Keys
+ *
+ * The `ord` namespace reserves the following label keys for standardized use:
+ *
+ * - `ord:ai-hint`: Provides a hint for AI consumers (e.g., LLMs) on how to use or interpret the ORD resource. Intentionally kept separate from human-readable description fields so that end-user-facing documentation and AI-targeted guidance can evolve independently. MUST contain exactly one value. The value SHOULD be in [CommonMark](https://spec.commonmark.org/) (Markdown) format.
  */
 export interface Labels {
+  /**
+   * Provides a hint for AI consumers (e.g., LLMs) on how to use or interpret the ORD resource.
+   * Intentionally kept separate from human-readable description fields so that end-user-facing documentation
+   * and AI-targeted guidance can evolve independently.
+   * MUST contain exactly one value. The value SHOULD be in CommonMark (Markdown) format.
+   *
+   * @maxItems 1
+   */
+  "ord:ai-hint"?: [] | [string];
   /**
    * This interface was referenced by `Labels`'s JSON-Schema definition
    * via the `patternProperty` "^[a-zA-Z0-9-_.:/]*$".

--- a/src/generated/spec/v1/types/Document.ts
+++ b/src/generated/spec/v1/types/Document.ts
@@ -209,12 +209,6 @@ export interface SystemType {
  *
  * **RECOMMENDATION**: Use a [Concept ID](../index.md#concept-id) as the label key to indicate ownership and avoid naming conflicts.
  * The namespace in the Concept ID clearly identifies who owns and defines the label's semantics.
- *
- * ### Pre-defined Label Keys
- *
- * The `ord` namespace reserves the following label keys for standardized use:
- *
- * - `ord:ai-hint`: Provides a hint for AI consumers (e.g., LLMs) on how to use or interpret the ORD resource. Intentionally kept separate from human-readable description fields so that end-user-facing documentation and AI-targeted guidance can evolve independently. MUST contain exactly one value. The value SHOULD be in [CommonMark](https://spec.commonmark.org/) (Markdown) format.
  */
 export interface Labels {
   /**

--- a/static/spec-v1/interfaces/ums/MetadataType/agent.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/agent.yaml
@@ -51,6 +51,11 @@ spec:
       description: "Full description, notated in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nThe description SHOULD not be excessive in length and is not meant to provide full documentation.\nDetailed documentation SHOULD be attached as (typed) links."
       constraints:
         minLength: 1
+    - name: 'aiHint'
+      type: 'string'
+      description: "Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.\nIntentionally separate from human-facing `description` so both can evolve independently.\nSHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nFor guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources)."
+      constraints:
+        minLength: 1
     - name: 'partOfPackage_ID'
       type: 'guid'
       description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."

--- a/static/spec-v1/interfaces/ums/MetadataType/apiresource.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/apiresource.yaml
@@ -53,6 +53,11 @@ spec:
       mandatory: true
       constraints:
         minLength: 1
+    - name: 'aiHint'
+      type: 'string'
+      description: "Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.\nIntentionally separate from human-facing `description` so both can evolve independently.\nSHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nFor guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources)."
+      constraints:
+        minLength: 1
     - name: 'partOfPackage_ID'
       type: 'guid'
       description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."

--- a/static/spec-v1/interfaces/ums/MetadataType/capability.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/capability.yaml
@@ -61,6 +61,11 @@ spec:
       description: "Full description, notated in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nThe description SHOULD not be excessive in length and is not meant to provide full documentation.\nDetailed documentation SHOULD be attached as (typed) links."
       constraints:
         minLength: 1
+    - name: 'aiHint'
+      type: 'string'
+      description: "Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.\nIntentionally separate from human-facing `description` so both can evolve independently.\nSHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nFor guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources)."
+      constraints:
+        minLength: 1
     - name: 'partOfPackage_ID'
       type: 'guid'
       description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."

--- a/static/spec-v1/interfaces/ums/MetadataType/dataproduct.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/dataproduct.yaml
@@ -53,6 +53,11 @@ spec:
       mandatory: true
       constraints:
         minLength: 1
+    - name: 'aiHint'
+      type: 'string'
+      description: "Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.\nIntentionally separate from human-facing `description` so both can evolve independently.\nSHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nFor guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources)."
+      constraints:
+        minLength: 1
     - name: 'partOfPackage_ID'
       type: 'guid'
       description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."

--- a/static/spec-v1/interfaces/ums/MetadataType/entitytype.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/entitytype.yaml
@@ -52,6 +52,11 @@ spec:
       description: "Full description, notated in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nThe description SHOULD not be excessive in length and is not meant to provide full documentation.\nDetailed documentation SHOULD be attached as (typed) links."
       constraints:
         minLength: 1
+    - name: 'aiHint'
+      type: 'string'
+      description: "Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.\nIntentionally separate from human-facing `description` so both can evolve independently.\nSHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nFor guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources)."
+      constraints:
+        minLength: 1
     - name: 'partOfPackage_ID'
       type: 'guid'
       description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."

--- a/static/spec-v1/interfaces/ums/MetadataType/eventresource.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/eventresource.yaml
@@ -53,6 +53,11 @@ spec:
       mandatory: true
       constraints:
         minLength: 1
+    - name: 'aiHint'
+      type: 'string'
+      description: "Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.\nIntentionally separate from human-facing `description` so both can evolve independently.\nSHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nFor guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources)."
+      constraints:
+        minLength: 1
     - name: 'partOfPackage_ID'
       type: 'guid'
       description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."


### PR DESCRIPTION
### Added

- Added `aiHint` as a dedicated, optional property on API Resources, Event Resources, Entity Types, Data Products, Agents, and Capabilities. Provides guidance targeted at AI consumers (LLMs, orchestrators), kept intentionally separate from human-readable `description` fields so both can evolve independently. SHOULD be CommonMark Markdown. See [AI Agents and Protocols](https://open-resource-discovery.org/spec-v1/concepts/ai-agents-and-protocols#ai-hints-on-ord-resources).

Obsoletes #141 