### PR TITLE
Fix provider baseUrl fallback: derive from well-known config endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ### Fixed
 
-- Clarified that base-URL-relative URLs (leading `/`) in ORD use **ORD-specific concatenation semantics** (`baseUrl + "/" + path`), not RFC 3986 root-relative resolution (which strips the base path). Renamed the URL reference type from "Root-relative" to "Base-URL-relative" to avoid the RFC 3986 naming conflict. Added explicit concatenation rule and no-`baseUrl` fallback (scheme+authority only, which coincides with RFC 3986 behavior). Document-relative (`./`, `../`) URLs continue to follow RFC 3986 §5 unchanged.
+- Clarified that base-URL-relative URLs (leading `/`) in ORD use **ORD-specific concatenation semantics** (`baseUrl + "/" + path`), not RFC 3986 root-relative resolution (which strips the base path). Renamed the URL reference type from "Root-relative" to "Base-URL-relative" to avoid the RFC 3986 naming conflict. Added explicit concatenation rule. Document-relative (`./`, `../`) URLs continue to follow RFC 3986 §5 unchanged.
+- Clarified the last-resort fallback for the provider base URL: when no `baseUrl`, fetch context, or `describedSystemInstance.baseUrl` is available, the base URL is derived from the ORD configuration endpoint by stripping the `/.well-known/open-resource-discovery` suffix — consistent with how `Configuration.baseUrl` is implicitly computed when omitted.
   See [issue #145](https://github.com/open-resource-discovery/specification/issues/145).
 
 ### Added

--- a/docs/spec-v1/index.md
+++ b/docs/spec-v1/index.md
@@ -328,7 +328,7 @@ ORD recognizes three types of URL references:
 **Base-URL-relative URLs** (leading slash) are resolved by appending the reference path to the applicable base URL: `baseUrl + "/" + ref_path_without_leading_slash`.
 For example, if `baseUrl` is `https://provider.com/api/v1`, then `/metadata/schema.json` resolves to `https://provider.com/api/v1/metadata/schema.json`.
 
-If no base URL is known (neither explicitly declared nor determinable from fetch context), the fallback is to treat the base URL as scheme+authority only (e.g. `https://provider.com`), which produces the same result as standard [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-5) root-relative resolution.
+If no base URL is known through any other means, it is derived from the [ORD configuration endpoint](#ord-configuration-endpoint) URL by stripping the `/.well-known/open-resource-discovery` suffix — consistent with how the ORD Configuration's implicit `baseUrl` is defined. For example, if the config endpoint is `https://provider.com/api/v1/.well-known/open-resource-discovery`, the derived base URL is `https://provider.com/api/v1`.
 
 **Document-relative URLs** (with `./`, `../`, or bare path without leading slash) are resolved per [RFC 3986 Section 5](https://datatracker.ietf.org/doc/html/rfc3986#section-5) against the URL from which the current document was retrieved.
 For example, if a document was fetched from `https://provider.com/ord/v1/documents/apis.json`, then `./schemas.json` resolves to `https://provider.com/ord/v1/documents/schemas.json`.
@@ -356,8 +356,7 @@ Their base-URL-relative URLs are resolved against the provider base URL using th
 1. **Document root `baseUrl`** — takes precedence when explicitly set in the document.
 2. **Fetch context URL** (pull scenarios only) — the URL the ORD document was fetched from.
 3. **`describedSystemInstance.baseUrl`** — backward-compatibility fallback for documents predating version 1.15 that do not set the document root `baseUrl`. In the common case where provider and described system are the same, this yields the same result.
-
-If none of the above are available, the scheme+authority of any known URL for the provider MAY be used as fallback.
+4. **ORD configuration endpoint URL** — if the aggregator knows the provider's `/.well-known/open-resource-discovery` endpoint, the base URL is derived by stripping that suffix. This ensures consistent fallback behavior with how `Configuration.baseUrl` is implicitly computed when omitted.
 
 ##### Described System Base URL (entry points)
 


### PR DESCRIPTION
When no baseUrl is available through any other means, derive it by stripping the /.well-known/open-resource-discovery suffix from the known config endpoint URL. Aligns with the existing implicit baseUrl rule in Configuration.schema.yaml and avoids the vague scheme+authority fallback that could produce wrong results when the provider is mounted under a path prefix.

Also removes the RFC 3986 fallback mention from the base-URL-relative introductory paragraph — the well-known rule is the specified fallback.