### PR TITLE
Add labels to Integration Dependency sub-objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ docs/spec-extensions/models/*.md
 .claude/
 .codex
 .DS_Store
+grounding/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+## [1.16.1]
+
+### Added
+
+- Added `labels` property to `IntegrationAspect`, `ApiResourceIntegrationAspect`, `EventResourceIntegrationAspect`, and `CapabilityIntegrationAspect`.
+
 ## [1.16.0]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@docusaurus/theme-mermaid": "3.10.1",
 				"@easyops-cn/docusaurus-search-local": "0.55.2",
 				"@mdx-js/react": "3.1.1",
-				"@open-resource-discovery/spec-toolkit": "0.8.0",
+				"@open-resource-discovery/spec-toolkit": "0.8.1",
 				"@types/fs-extra": "11.0.4",
 				"ajv": "8.20.0",
 				"ajv-formats": "3.0.1",
@@ -5955,25 +5955,25 @@
 			}
 		},
 		"node_modules/@open-resource-discovery/spec-toolkit": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/@open-resource-discovery/spec-toolkit/-/spec-toolkit-0.8.0.tgz",
-			"integrity": "sha512-kj5keSzXpEwyJS8o2t+u1aHu/G+UgASa7ni4xJxuqiwYt/vPHmtuToGL67gskMAJ2fmJZWUjPXYIiOeMU8sgjw==",
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@open-resource-discovery/spec-toolkit/-/spec-toolkit-0.8.1.tgz",
+			"integrity": "sha512-Pdc6KgS5ngLtdx11X0XWEJNt9ih3Fc/FJG+FGEvYmgrEmwfemH0ytahyiUfR1vppY6YvFgcPmjumy4FGggWrmg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"ajv": "8.18.0",
+				"ajv": "8.20.0",
 				"ajv-formats": "3.0.1",
 				"commander": "14.0.3",
 				"comment-json": "4.6.2",
 				"exceljs": "4.4.0",
 				"fast-glob": "3.3.3",
-				"fs-extra": "11.3.4",
+				"fs-extra": "11.3.5",
 				"gfm-escape": "0.2.0",
-				"js-yaml": "4.1.1",
+				"js-yaml": "4.2.0",
 				"json-schema-to-typescript": "15.0.4",
-				"lodash": "4.17.23",
+				"lodash": "4.18.1",
 				"quicktype-core": "23.2.6",
-				"tslog": "4.9.3"
+				"tslog": "4.10.2"
 			},
 			"bin": {
 				"spec-toolkit": "dist/cli.js"
@@ -5981,23 +5981,6 @@
 			"engines": {
 				"node": ">=22.0.0",
 				"npm": ">=10.0.0"
-			}
-		},
-		"node_modules/@open-resource-discovery/spec-toolkit/node_modules/ajv": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
 		"node_modules/@open-resource-discovery/spec-toolkit/node_modules/commander": {
@@ -6008,34 +5991,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
-			}
-		},
-		"node_modules/@open-resource-discovery/spec-toolkit/node_modules/fs-extra": {
-			"version": "11.3.4",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-			"integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.14"
-			}
-		},
-		"node_modules/@open-resource-discovery/spec-toolkit/node_modules/tslog": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/tslog/-/tslog-4.9.3.tgz",
-			"integrity": "sha512-oDWuGVONxhVEBtschLf2cs/Jy8i7h1T+CpdkTNWQgdAF7DhRo2G8vMCgILKe7ojdEkLhICWgI1LYSSKaJsRgcw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/fullstack-build/tslog?sponsor=1"
 			}
 		},
 		"node_modules/@peculiar/asn1-cms": {
@@ -14472,10 +14427,20 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -15359,9 +15324,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@open-resource-discovery/specification",
-	"version": "1.16.0",
+	"version": "1.16.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@open-resource-discovery/specification",
-			"version": "1.16.0",
+			"version": "1.16.1",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@biomejs/biome": "2.4.16",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"@docusaurus/theme-mermaid": "3.10.1",
 		"@easyops-cn/docusaurus-search-local": "0.55.2",
 		"@mdx-js/react": "3.1.1",
-		"@open-resource-discovery/spec-toolkit": "0.8.0",
+		"@open-resource-discovery/spec-toolkit": "0.8.1",
 		"@types/fs-extra": "11.0.4",
 		"ajv": "8.20.0",
 		"ajv-formats": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://json.schemastore.org/package",
 	"name": "@open-resource-discovery/specification",
-	"version": "1.16.0",
+	"version": "1.16.1",
 	"description": "Open Resource Discovery (ORD) Specification",
 	"author": "SAP SE",
 	"license": "Apache-2.0",

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -3889,6 +3889,9 @@ definitions:
         items:
           $ref: "#/definitions/CapabilityIntegrationAspect"
 
+      labels:
+        <<: *labels
+
     additionalProperties: false
     required:
       - title # TODO: Do we need a mandatory title?
@@ -3936,6 +3939,9 @@ definitions:
       #     pattern: ^([a-z0-9]+(?:[.][a-z0-9]+]*):(consumptionBundle):([a-zA-Z0-9._\-]+):(alpha|beta|v[0-9]+|)$
       #   examples:
       #     - ['sap.foo:consumptionBundle:basicAuth:v1']
+
+      labels:
+        <<: *labels
 
     additionalProperties: false
     required:
@@ -3985,6 +3991,9 @@ definitions:
 
       # consumptionBundleRestriction:
       #   <<: *consumptionBundleRestriction
+
+      labels:
+        <<: *labels
 
     additionalProperties: false
     required:
@@ -4066,6 +4075,9 @@ definitions:
 
       minVersion:
         <<: *minVersion
+
+      labels:
+        <<: *labels
 
     additionalProperties: false
     required:

--- a/src/generated/spec/v1/types/Document.ts
+++ b/src/generated/spec/v1/types/Document.ts
@@ -3713,6 +3713,7 @@ export interface Aspect {
    * List of Capability Dependencies.
    */
   capabilities?: CapabilityIntegrationAspect[];
+  labels?: Labels;
 }
 /**
  * API resource related integration aspect
@@ -3738,6 +3739,7 @@ export interface ApiResourceIntegrationAspect {
    * For more details and examples, see [Integration Dependency](../concepts/integration-dependency).
    */
   subset?: APIResourceIntegrationAspectSubset[];
+  labels?: Labels;
 }
 /**
  * Defines that the API Resource Integration Aspect only requires a subset of the referenced contract.
@@ -3785,6 +3787,7 @@ export interface EventResourceIntegrationAspect {
    * @minItems 1
    */
   systemTypeRestriction?: [string, ...string[]];
+  labels?: Labels;
 }
 /**
  * Defines that Event Resource Integration Aspect only requires a subset of the referenced contract.
@@ -3816,6 +3819,7 @@ export interface CapabilityIntegrationAspect {
    *
    */
   minVersion?: string;
+  labels?: Labels;
 }
 /**
  * The vendor of a product or a package, usually a corporation or a customer / user.

--- a/static/spec-v1/interfaces/ums/MetadataType/integrationdependency.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/integrationdependency.yaml
@@ -153,6 +153,10 @@ spec:
           customTypeName: 'CapabilityIntegrationAspect'
           array: true
           description: 'List of Capability Dependencies.'
+        - name: 'labels'
+          type: 'custom'
+          customTypeName: 'Labels'
+          description: 'Generic labels that can be applied to most ORD information.'
     - name: 'ApiResourceIntegrationAspect'
       metadataProperties:
         - name: 'ordId'
@@ -172,12 +176,22 @@ spec:
           customTypeName: 'ApiResourceIntegrationAspectSubset'
           array: true
           description: "Narrows the dependency to only the listed API operations (or MCP tools) that are required to achieve the aspect.\n\nIf `subset` is not provided, the dependency implies that all operations of the referenced resource may be used.\nIf `subset` is provided, only the listed operations are required — consumers MUST NOT assume that other operations are available or permitted.\n\nFor more details and examples, see [Integration Dependency](../concepts/integration-dependency)."
+        - name: 'labels'
+          type: 'custom'
+          customTypeName: 'Labels'
+          description: 'Generic labels that can be applied to most ORD information.'
     - name: 'ApiResourceIntegrationAspectSubset'
       metadataProperties:
         - name: 'operationId'
           type: 'string'
           description: "The ID of the individual API operation or tool.\n\nThis MUST be an ID that is understood by the used protocol and resource definition format.\nE.g. for OpenAPI this is the `operationId`, for MCP this is the tool `name`."
           mandatory: true
+    - name: 'Labels'
+      metadataProperties:
+        - name: 'key'
+          type: 'string'
+        - name: 'value'
+          type: 'string'
     - name: 'EventResourceIntegrationAspect'
       metadataProperties:
         - name: 'ordId'
@@ -201,6 +215,10 @@ spec:
           type: 'string'
           array: true
           description: "In case that the event subscriptions are limited to known [system types](../index.md#system-type), they can be listed here as [system namespaces](../index.md#system-namespace).\n\nIf given, only system types of the defined namespaces are supported as integration partners.\nIf not given, there is no restriction which system type provides the events."
+        - name: 'labels'
+          type: 'custom'
+          customTypeName: 'Labels'
+          description: 'Generic labels that can be applied to most ORD information.'
     - name: 'EventResourceIntegrationAspectSubset'
       metadataProperties:
         - name: 'eventType'
@@ -221,6 +239,10 @@ spec:
           description: "Minimum version of the references resource that the integration requires.\n"
           constraints:
             pattern: '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+        - name: 'labels'
+          type: 'custom'
+          customTypeName: 'Labels'
+          description: 'Generic labels that can be applied to most ORD information.'
     - name: 'Link'
       metadataProperties:
         - name: 'title'
@@ -238,12 +260,6 @@ spec:
           description: 'Full description, notated in [CommonMark](https://spec.commonmark.org/) (Markdown).'
           constraints:
             minLength: 1
-    - name: 'Labels'
-      metadataProperties:
-        - name: 'key'
-          type: 'string'
-        - name: 'value'
-          type: 'string'
     - name: 'DocumentationLabels'
       metadataProperties:
         - name: 'key'


### PR DESCRIPTION
Patch release to add label extensibility where one stakeholder requested it.

Unfortunately we have a bug in spec-toolkit that needs to be fixed first:
- https://github.com/open-resource-discovery/spec-toolkit/pull/74

## [1.16.1]

### Added

- Added `labels` property to `IntegrationAspect`, `ApiResourceIntegrationAspect`, `EventResourceIntegrationAspect`, and `CapabilityIntegrationAspect`.
