### PR TITLE
New standardized purpose value: ord:agent-security-permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+## [1.16.2]
+
 ### Added
 
 - Added new `purpose` value `ord:agent-security-permissions` for resource definitions that describe the security permissions an AI agent requires to access the resource.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+### Added
+
+- Added new `purpose` value `ord:agent-security-permissions` for resource definitions that describe the security permissions an AI agent requires to access the resource.
+
 ## [1.16.1]
 
 ### Added

--- a/examples/overlay/a2a-dispute-agent.overlay.json
+++ b/examples/overlay/a2a-dispute-agent.overlay.json
@@ -4,7 +4,6 @@
   "ordId": "sap.foo:overlay:dispute-agent-a2a:v1",
   "description": "Enriches the Dispute Resolution Agent Card (A2A format) with extended descriptions, usage guidance, and classification metadata without modifying the original Agent Card file.\n\nThe 'operation' selector maps to A2A Agent Card skill IDs (skills[].id).",
   "visibility": "private",
-  },
   "target": {
     "ordId": "sap.foo:apiResource:FICADisputeResolutionAgent:v1",
     "url": "./DisputeResolutionAgentcard.json",

--- a/examples/overlay/a2a-dispute-agent.overlay.json
+++ b/examples/overlay/a2a-dispute-agent.overlay.json
@@ -4,11 +4,6 @@
   "ordId": "sap.foo:overlay:dispute-agent-a2a:v1",
   "description": "Enriches the Dispute Resolution Agent Card (A2A format) with extended descriptions, usage guidance, and classification metadata without modifying the original Agent Card file.\n\nThe 'operation' selector maps to A2A Agent Card skill IDs (skills[].id).",
   "visibility": "private",
-  "meta": {
-    "simple": "foo",
-    "someMetadataKey": {
-      "complex": "object"
-    }
   },
   "target": {
     "ordId": "sap.foo:apiResource:FICADisputeResolutionAgent:v1",

--- a/examples/overlay/a2a-dispute-agent.overlay.json
+++ b/examples/overlay/a2a-dispute-agent.overlay.json
@@ -4,6 +4,12 @@
   "ordId": "sap.foo:overlay:dispute-agent-a2a:v1",
   "description": "Enriches the Dispute Resolution Agent Card (A2A format) with extended descriptions, usage guidance, and classification metadata without modifying the original Agent Card file.\n\nThe 'operation' selector maps to A2A Agent Card skill IDs (skills[].id).",
   "visibility": "private",
+  "meta": {
+    "simple": "foo",
+    "someMetadataKey": {
+      "complex": "object"
+    }
+  },
   "target": {
     "ordId": "sap.foo:apiResource:FICADisputeResolutionAgent:v1",
     "url": "./DisputeResolutionAgentcard.json",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@open-resource-discovery/specification",
-	"version": "1.16.1",
+	"version": "1.16.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@open-resource-discovery/specification",
-			"version": "1.16.1",
+			"version": "1.16.2",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@biomejs/biome": "2.4.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://json.schemastore.org/package",
 	"name": "@open-resource-discovery/specification",
-	"version": "1.16.1",
+	"version": "1.16.2",
 	"description": "Open Resource Discovery (ORD) Specification",
 	"author": "SAP SE",
 	"license": "Apache-2.0",

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -2945,6 +2945,11 @@ definitions:
               The definition is enriched with additional metadata specifically for AI/agent consumption.
               This may include enhanced descriptions, examples, or semantic annotations that help AI systems
               better understand and utilize the API or event resource.
+          - const: ord:agent-security-permissions
+            description: |-
+              The definition describes the security permissions an AI agent requires to access the resource.
+              This allows agent runtimes and consent flows to discover and request the appropriate
+              authorizations before the agent invokes the resource.
         examples:
           - ord:ai-enrichment
 

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -2945,11 +2945,13 @@ definitions:
               The definition is enriched with additional metadata specifically for AI/agent consumption.
               This may include enhanced descriptions, examples, or semantic annotations that help AI systems
               better understand and utilize the API or event resource.
+            x-introduced-in-version: "1.15.0"
           - const: ord:agent-security-permissions
             description: |-
               The definition describes the security permissions an AI agent requires to access the resource.
               This allows agent runtimes and consent flows to discover and request the appropriate
               authorizations before the agent invokes the resource.
+            x-introduced-in-version: "1.16.2"
         examples:
           - ord:ai-enrichment
 

--- a/src/generated/spec/v1/types/Document.ts
+++ b/src/generated/spec/v1/types/Document.ts
@@ -1061,7 +1061,7 @@ export interface ApiResourceDefinition {
    *
    * MUST be a valid [Concept ID](../index.md#concept-id).
    */
-  purpose?: (string | "ord:ai-enrichment") & string;
+  purpose?: (string | "ord:ai-enrichment" | "ord:agent-security-permissions") & string;
 }
 /**
  * Defines the [access strategy](../../spec-extensions/access-strategies/) for accessing the resource definitions.
@@ -1836,7 +1836,7 @@ export interface EventResourceDefinition {
    *
    * MUST be a valid [Concept ID](../index.md#concept-id).
    */
-  purpose?: (string | "ord:ai-enrichment") & string;
+  purpose?: (string | "ord:ai-enrichment" | "ord:agent-security-permissions") & string;
 }
 /**
  * Describes the compatibility of the Event with other Events. This can be used to express that an Event is compatible with another Event version.
@@ -2519,7 +2519,7 @@ export interface CapabilityDefinition {
    *
    * MUST be a valid [Concept ID](../index.md#concept-id).
    */
-  purpose?: (string | "ord:ai-enrichment") & string;
+  purpose?: (string | "ord:ai-enrichment" | "ord:agent-security-permissions") & string;
 }
 /**
  * A [Data Product](../concepts/data-product) is a data set exposed for consumption outside the boundaries of the producing application via APIs and described by high quality metadata that can be accessed through the [ORD Aggregator](../../spec-v1/#ord-aggregator).
@@ -3476,7 +3476,7 @@ export interface OverlayDefinition {
    *
    * MUST be a valid [Concept ID](../index.md#concept-id).
    */
-  purpose?: (string | "ord:ai-enrichment") & string;
+  purpose?: (string | "ord:ai-enrichment" | "ord:agent-security-permissions") & string;
 }
 /**
  * An [Integration Dependency](../concepts/integration-dependency) states that the described system (self) can integrate with external systems (integration target) to achieve an integration purpose.


### PR DESCRIPTION
### Added

- Added new `purpose` value `ord:agent-security-permissions` for resource definitions that describe the security permissions an AI agent requires to access the resource.
