### PR TITLE
Clarify sap:base:v1: reserve both ord: and sap: prefixes in extensible enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,6 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
-### Changed
-
-- `sap:base:v1`: Clarified that extensible enum values reserve both the `ord:` and the `sap:` root prefixes. Application-specific values MUST use a sub-namespace such as `sap.foo:...` (e.g., `sap.s4:...`); the bare `sap:` prefix is reserved for centrally aligned, specification-defined values.
-
 ## [1.16.3]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+### Changed
+
+- `sap:base:v1`: Clarified that extensible enum values reserve both the `ord:` and the `sap:` root prefixes. Application-specific values MUST use a sub-namespace such as `sap.foo:...` (e.g., `sap.s4:...`); the bare `sap:` prefix is reserved for centrally aligned, specification-defined values.
+
 ## [1.16.3]
 
 ### Changed

--- a/docs/spec-extensions/policy-levels/sap-base-v1.md
+++ b/docs/spec-extensions/policy-levels/sap-base-v1.md
@@ -28,7 +28,7 @@ Usually SAP applications and services will use the more complete and opinionated
 
 ### Extensible Enums
 
-- In extensible enums whose values are namespace-prefixed (i.e., use a [Specification ID](../../spec-v1/index.md#specification-id), [Concept ID](../../spec-v1/index.md#concept-id), or [Correlation ID](../../spec-v1/index.md#correlation-id) — e.g. `purpose`, `relationType`, `correlationIds`, ...), the `ord:` and the root `sap:` prefixes are reserved for centrally aligned, specification-defined values.
+- In extensible enums whose values are namespace-prefixed (i.e., use a [Specification ID](../../spec-v1/index.md#specification-id), [Concept ID](../../spec-v1/index.md#concept-id), or [Correlation ID](../../spec-v1/index.md#correlation-id), e.g. `purpose`, `relationType`, `correlationIds`, ...), the `ord:` and the root `sap:` prefixes are reserved for centrally aligned, specification-defined values.
   - The `ord:` prefix MUST NOT be used by vendors (reserved for the ORD specification itself).
   - The root `sap:` prefix MUST NOT be used for application-specific values. Applications and services MUST use a sub-namespace such as `sap.foo:...` instead (e.g. `sap.s4:...` is allowed, `sap:...` is not).
 

--- a/docs/spec-extensions/policy-levels/sap-base-v1.md
+++ b/docs/spec-extensions/policy-levels/sap-base-v1.md
@@ -25,6 +25,12 @@ Usually SAP applications and services will use the more complete and opinionated
   - All ORD resources owned by SAP MUST use the `sap` vendor namespace
   - ORD resources / extensions created by the customer MAY use the `customer` vendor namespace or MUST use their own vendor namespace.
 
+### Extensible Enums
+
+- Values in [extensible enums](../../spec-v1/index.md#namespaces) reserve both the `ord:` and the `sap:` root prefixes for centrally aligned, specification-defined values.
+  - The `ord:` prefix MUST NOT be used by vendors (reserved for the ORD specification itself).
+  - The `sap:` root prefix MUST NOT be used for application-specific values. Applications and services MUST use a sub-namespace such as `sap.foo:...` instead. Example: `sap.s4:...` is allowed, `sap:...` is not.
+
 ### Packages
 
 - The vendor of a Package MUST be set and be equal to one of the allowed values: `sap:vendor:SAP:`, `customer:vendor:Customer:`.

--- a/docs/spec-extensions/policy-levels/sap-base-v1.md
+++ b/docs/spec-extensions/policy-levels/sap-base-v1.md
@@ -16,6 +16,7 @@ Usually SAP applications and services will use the more complete and opinionated
 ## General Policies
 
 ### Policy Levels
+
 - SAP applications and services MAY define custom policy levels, but they MUST be namespaced under their application-specific namespace, e.g. `sap.s4:core:v1`.
 - Only centrally aligned policy levels (such as `sap:base:v1` or `sap:core:v1`) MAY use the root `sap` namespace. Custom policy levels MUST NOT use the root `sap` namespace, e.g. `sap:s4:v1` is not allowed.
 
@@ -27,9 +28,9 @@ Usually SAP applications and services will use the more complete and opinionated
 
 ### Extensible Enums
 
-- Values in [extensible enums](../../spec-v1/index.md#namespaces) reserve both the `ord:` and the `sap:` root prefixes for centrally aligned, specification-defined values.
+- In extensible enums whose values are namespace-prefixed (i.e., use a [Specification ID](../../spec-v1/index.md#specification-id), [Concept ID](../../spec-v1/index.md#concept-id), or [Correlation ID](../../spec-v1/index.md#correlation-id) — e.g. `purpose`, `relationType`, `correlationIds`, ...), the `ord:` and the root `sap:` prefixes are reserved for centrally aligned, specification-defined values.
   - The `ord:` prefix MUST NOT be used by vendors (reserved for the ORD specification itself).
-  - The `sap:` root prefix MUST NOT be used for application-specific values. Applications and services MUST use a sub-namespace such as `sap.foo:...` instead. Example: `sap.s4:...` is allowed, `sap:...` is not.
+  - The root `sap:` prefix MUST NOT be used for application-specific values. Applications and services MUST use a sub-namespace such as `sap.foo:...` instead (e.g. `sap.s4:...` is allowed, `sap:...` is not).
 
 ### Packages
 

--- a/docs/spec-extensions/policy-levels/sap-base-v1.md
+++ b/docs/spec-extensions/policy-levels/sap-base-v1.md
@@ -28,7 +28,8 @@ Usually SAP applications and services will use the more complete and opinionated
 
 ### Extensible Enums
 
-- In extensible enums whose values are namespace-prefixed (i.e., use a [Specification ID](../../spec-v1/index.md#specification-id), [Concept ID](../../spec-v1/index.md#concept-id), or [Correlation ID](../../spec-v1/index.md#correlation-id), e.g. `purpose`, `relationType`, `correlationIds`, ...), the `ord:` and the root `sap:` prefixes are reserved for centrally aligned, specification-defined values.
+- The `ord:` and the root `sap:` prefixes are reserved for centrally aligned, specification-defined values in extensible enums whose values are namespace-prefixed.
+  This applies to any value that is a [Specification ID](../../spec-v1/index.md#specification-id), [Concept ID](../../spec-v1/index.md#concept-id), or [Correlation ID](../../spec-v1/index.md#correlation-id). Affected fields include `purpose`, `relationType`, `correlationIds`, and others.
   - The `ord:` prefix MUST NOT be used by vendors (reserved for the ORD specification itself).
   - The root `sap:` prefix MUST NOT be used for application-specific values. Applications and services MUST use a sub-namespace such as `sap.foo:...` instead (e.g. `sap.s4:...` is allowed, `sap:...` is not).
 


### PR DESCRIPTION
## Summary

- Adds an **Extensible Enums** subsection to the `sap:base:v1` policy that reserves both the `ord:` and the root `sap:` prefixes for centrally aligned, specification-defined values.
- Application-specific values MUST use a sub-namespace like `sap.foo:...` (e.g. `sap.s4:...`); the bare `sap:` prefix is not allowed, mirroring the existing `ord:` reservation.
- CHANGELOG entry under `[unreleased]`.

## Related

- #154 