### PR TITLE
Fix llm-notebook export: rename .mdx output to .md

### DIFF
--- a/src/helper/exportForNotebookLM.ts
+++ b/src/helper/exportForNotebookLM.ts
@@ -145,8 +145,8 @@ export async function exportForNotebookLM(): Promise<void> {
 				continue;
 			}
 
-			// Generate output filename: prefix + original filename
-			const originalFilename = path.basename(doc.src);
+			// Generate output filename: prefix + original filename (normalize .mdx to .md)
+			const originalFilename = path.basename(doc.src).replace(/\.mdx$/, ".md");
 			const outputFilename = `${doc.prefix}${originalFilename}`;
 			const destPath = path.join(outputDir, outputFilename);
 


### PR DESCRIPTION
## Summary
- `npm run generate:llm-notebook` was copying `.mdx` sources (e.g. `introduction.mdx`, `ecosystem/index.mdx`) into the output folder with their original extension. NotebookLM expects `.md`, so those files were unusable.
- Normalize the output filename to `.md` when the source is `.mdx`.

## Test plan
- [x] Run `npx ts-node ./src/helper/exportForNotebookLM.ts` and confirm all files in `src/generated/llm-notebook/` end in `.md`