### PR TITLE
Add oas-overlay-v1 resource definition type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+### Added
+
+- Added `oas-overlay-v1` as a resource definition `type` on API Resource Definitions and Event Resource Definitions. This allows publishers to expose [OpenAPI Initiative Overlay v1.0.0](https://spec.openapis.org/overlay/v1.0.0.html) documents directly through ORD.
+- Added `oas-overlay-v1` to the allowed values of `target.definitionType` on `OrdOverlay`, so ORD Overlays can target OpenAPI Overlay files.
+- Added an appendix section ["Relation to the OpenAPI Initiative Overlay Specification"](https://open-resource-discovery.org/spec-v1/interfaces/OrdOverlay#appendix-relation-to-the-openapi-initiative-overlay-specification) to the ORD Overlay documentation that describes what motivated a dedicated, ORD-opinionated overlay model, where the two specifications overlap, and how they interoperate.
+- `sap:core:v1` policy level: SAP applications and services MUST use `type: "ord:overlay:v1"` as the overlay format for all published overlays.
+
 ## [1.16.3]
 
 ### Changed

--- a/docs/spec-extensions/policy-levels/sap-core-v1.md
+++ b/docs/spec-extensions/policy-levels/sap-core-v1.md
@@ -197,6 +197,7 @@ The following constraints apply in addition to the constraints defined in the [O
 ### ORD Overlays
 
 - [ORD Overlays](../../spec-v1/interfaces/OrdOverlay.md) MUST always provide a [`target.ordId`](../../spec-v1/interfaces/OrdOverlay.md#overlay-target_ordid) to identify the ORD resource being patched.
+- SAP applications and services MUST use `type: "ord:overlay:v1"` as the overlay format for all published overlays. The `oas-overlay-v1` type is supported by the ORD specification for interoperability with the OpenAPI Initiative Overlay ecosystem, but within SAP we standardize on ORD Overlay because it works uniformly across all metadata formats we publish (OpenAPI, AsyncAPI, OData EDMX/CSDL, A2A, MCP, CSN Interop) and integrates with ORD identifiers, `purpose`, and `visibility`.
 
 ### Correlation IDs
 

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -2849,6 +2849,13 @@ definitions:
               ORD Overlay file for patching referenced resource definition files.
               For details, see [ORD Overlay](../../spec-v1/interfaces/OrdOverlay).
               The `mediaType` MUST be set to `application/json`.
+          - const: oas-overlay-v1
+            x-introduced-in-version: "1.17.0"
+            description: |-
+              [OpenAPI Overlay v1.0.0](https://spec.openapis.org/overlay/v1.0.0.html) document for patching an OpenAPI definition.
+              Use this when overlays are authored in the OpenAPI Initiative Overlay format rather than the
+              [ORD Overlay](../../spec-v1/interfaces/OrdOverlay) format.
+              The `mediaType` MUST be set to `application/json` or `application/yaml`.
           - const: custom
             description: |-
               If chosen, `customType` MUST be provided.
@@ -3006,6 +3013,13 @@ definitions:
               ORD Overlay file for patching metadata / resource definition files.
               For details, see [ORD Overlay](../../spec-v1/interfaces/OrdOverlay).
               The `mediaType` MUST be set to `application/json`.
+          - const: oas-overlay-v1
+            x-introduced-in-version: "1.17.0"
+            description: |-
+              [OpenAPI Overlay v1.0.0](https://spec.openapis.org/overlay/v1.0.0.html) document for patching an OpenAPI definition.
+              Use this when overlays are authored in the OpenAPI Initiative Overlay format rather than the
+              [ORD Overlay](../../spec-v1/interfaces/OrdOverlay) format.
+              The `mediaType` MUST be set to `application/json` or `application/yaml`.
           - const: custom
             description: |-
               If chosen, `customType` MUST be provided.

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -2850,7 +2850,7 @@ definitions:
               For details, see [ORD Overlay](../../spec-v1/interfaces/OrdOverlay).
               The `mediaType` MUST be set to `application/json`.
           - const: oas-overlay-v1
-            x-introduced-in-version: "1.17.0"
+            x-introduced-in-version: "1.16.4"
             description: |-
               [OpenAPI Overlay v1.0.0](https://spec.openapis.org/overlay/v1.0.0.html) document for patching an OpenAPI definition.
               Use this when overlays are authored in the OpenAPI Initiative Overlay format rather than the
@@ -3014,7 +3014,7 @@ definitions:
               For details, see [ORD Overlay](../../spec-v1/interfaces/OrdOverlay).
               The `mediaType` MUST be set to `application/json`.
           - const: oas-overlay-v1
-            x-introduced-in-version: "1.17.0"
+            x-introduced-in-version: "1.16.4"
             description: |-
               [OpenAPI Overlay v1.0.0](https://spec.openapis.org/overlay/v1.0.0.html) document for patching an OpenAPI definition.
               Use this when overlays are authored in the OpenAPI Initiative Overlay format rather than the

--- a/spec/v1/OrdOverlay.intro.md
+++ b/spec/v1/OrdOverlay.intro.md
@@ -6,6 +6,18 @@ This specification is in **alpha** and subject to change.
 The **ORD Overlay** is an optional ORD model extension that allows patching referenced resource definition files
 (e.g. OpenAPI, AsyncAPI, OData CSDL, MCP/A2A Agent Cards) without modifying the original source files.
 
+The ORD Overlay concept is inspired by the [OpenAPI Initiative Overlay Specification](https://spec.openapis.org/overlay/v1.0.0.html),
+which established the pattern of separating overlay content from the target definition file.
+ORD Overlay adopts that core idea but is intentionally dedicated and opinionated for the ORD ecosystem:
+it targets a broader set of metadata formats (not only OpenAPI), uses concept-level selectors that are resilient to
+format-version differences, and integrates with ORD identifiers, `purpose`, and `visibility`.
+For a detailed comparison and rationale, see
+[Appendix: Relation to the OpenAPI Initiative Overlay Specification](#appendix-relation-to-the-openapi-initiative-overlay-specification).
+
+If publishers prefer to author their overlays in the OpenAPI Initiative Overlay format directly,
+they can still expose them through ORD by attaching them as a resource definition with `type: oas-overlay-v1`.
+See the [API Resource Definition](../../spec-v1/interfaces/Document.md#api-resource-definition) type enum for details.
+
 ```json
 {
   "ordOverlay": "0.1",

--- a/spec/v1/OrdOverlay.outro.md
+++ b/spec/v1/OrdOverlay.outro.md
@@ -102,6 +102,58 @@ Rule of thumb:
 - use attached resource definitions for producer-owned, resource-local overlays
 - use ORD Document Resources for externally managed, cross-resource, or independently versioned overlays
 
+### Appendix: Relation to the OpenAPI Initiative Overlay Specification
+
+The [OpenAPI Initiative Overlay Specification](https://spec.openapis.org/overlay/v1.0.0.html) (OAS Overlay) inspired the overall idea of ORD Overlay:
+express metadata enrichment as a separate document that patches a target file, without modifying that file.
+ORD Overlay reuses that core pattern, and even preserves 1:1-compatible fields like `actions[].description` on individual patches to allow lossless round-tripping of OpenAPI-only overlays.
+
+However, ORD Overlay is intentionally a **dedicated, ORD-opinionated model** rather than a thin wrapper around OAS Overlay.
+This section explains what motivated a dedicated model and where the two specifications differ.
+
+#### Why a dedicated ORD Overlay model
+
+- **Multi-format targets.** OAS Overlay is defined against OpenAPI documents.
+  ORD-described resources use many other metadata formats — AsyncAPI, OData EDMX and CSDL JSON, GraphQL SDL,
+  A2A Agent Cards, MCP tool metadata, CSN Interop, SAP RFC / SQL API metadata, and more.
+  A single overlay model that works across all these formats is a native ORD concern and not in scope for OAS Overlay.
+- **Concept-level selectors instead of only JSONPath.** OAS Overlay uses JSONPath as its selector language.
+  JSONPath is powerful but tightly couples the overlay to the structural layout of a specific format version.
+  ORD Overlay defines concept-level selectors (`operation`, `entityType`, `entitySet`, `parameter`, `returnType`, ...)
+  that are resilient to structural changes (e.g. OpenAPI 3.0 to 3.1, EDMX to CSDL JSON).
+  `jsonPath` is still available as a generic fallback.
+- **Integration with ORD identifiers.** ORD Overlay's `target.ordId` and `target.definitionType` connect an overlay
+  directly to the ORD resource graph, so ORD Aggregators can resolve, authorize, and merge overlays without
+  format-specific heuristics.
+- **`purpose` and `visibility` on overlays and their patches.** ORD Overlay carries first-class `purpose`
+  (e.g. `ord:ai-enrichment`, `ord:agent-security-permissions`) and `visibility` on the overlay resource definition entry.
+  This enables audience-scoped variants and governance decisions that OAS Overlay does not model.
+- **Explicit patch actions.** OAS Overlay expresses removal via an `remove: true` flag and updates via `update` payloads.
+  ORD Overlay uses three explicit actions — `update`, `merge`, `remove` — with well-defined semantics per action
+  (including JSON Merge Patch style delete via `null`), which fits the wider range of target formats better
+  than a single JSONPath-driven mutation.
+- **First-class publishing paths.** Overlays can be attached to an API/Event resource as a
+  `resourceDefinitions` entry with `type: ord:overlay:v1`, or published as a standalone `OrdOverlayResource`
+  in an ORD Document. Both paths participate in normal ORD discovery, authorization, and lifecycle handling.
+- **Overlay-specific perspective.** The overlay `perspective` (`system-type`, `system-version`, `system-instance`)
+  scopes *where the patch applies*, which has no analogue in OAS Overlay.
+
+#### Where the two specifications overlap
+
+- Both keep overlays as a separate file from the target, to preserve the original source.
+- Both support enrichment (adding descriptions, annotations, examples) as the primary use case.
+- ORD Overlay `patches[].description` maps 1:1 to OAS Overlay `actions[].description`, enabling
+  lossless round-trip conversion for OpenAPI-only overlays.
+
+#### Interoperability with OAS Overlay documents
+
+Publishers who prefer authoring their overlays in the OpenAPI Initiative Overlay format can still expose them
+through ORD by attaching the file as a resource definition with `type: oas-overlay-v1` on the corresponding
+API resource, or by describing it via an `OrdOverlayResource` whose `definitions` entry uses that type.
+This keeps OAS Overlay documents discoverable through ORD without forcing them into the ORD Overlay format.
+
+Conversion between the two formats is possible for the OpenAPI subset of targets, but not required by this specification.
+
 ## Compatibility Expectations
 
 Overlays SHOULD NOT change the target in incompatible ways.

--- a/spec/v1/OrdOverlay.schema.yaml
+++ b/spec/v1/OrdOverlay.schema.yaml
@@ -282,6 +282,7 @@ definitions:
           - const: sap-csn-interop-effective-v1
           - const: asyncapi-v2
           - const: sap.mdo:mdi-capability-definition:v1
+          - const: oas-overlay-v1
         examples:
           - "openapi-v3"
           - "asyncapi-v2"

--- a/src/generated/spec/v1/types/Document.ts
+++ b/src/generated/spec/v1/types/Document.ts
@@ -1001,6 +1001,7 @@ export interface ApiResourceDefinition {
     | "sap-sql-api-definition-v1"
     | "sap-csn-interop-effective-v1"
     | "ord:overlay:v1"
+    | "oas-overlay-v1"
     | "custom"
   ) &
     string;
@@ -1783,7 +1784,8 @@ export interface EventResourceDefinition {
   /**
    * Type of the event resource definition
    */
-  type: (string | "asyncapi-v2" | "sap-csn-interop-effective-v1" | "ord:overlay:v1" | "custom") & string;
+  type: (string | "asyncapi-v2" | "sap-csn-interop-effective-v1" | "ord:overlay:v1" | "oas-overlay-v1" | "custom") &
+    string;
   /**
    * If the fixed `type` enum values need to be extended, an arbitrary `customType` can be provided.
    *

--- a/src/generated/spec/v1/types/OrdOverlay.ts
+++ b/src/generated/spec/v1/types/OrdOverlay.ts
@@ -66,6 +66,7 @@ export type OverlayDefinitionType = (
   | "sap-csn-interop-effective-v1"
   | "asyncapi-v2"
   | "sap.mdo:mdi-capability-definition:v1"
+  | "oas-overlay-v1"
 ) &
   string;
 /**


### PR DESCRIPTION
## Summary

- Adds `oas-overlay-v1` as a resource definition `type` on API and Event Resource Definitions, and as a valid `target.definitionType` on ORD Overlay. This lets publishers expose [OpenAPI Initiative Overlay v1.0.0](https://spec.openapis.org/overlay/v1.0.0.html) documents directly through ORD.
- Extends the ORD Overlay intro to note that ORD Overlay is inspired by the OpenAPI Initiative Overlay Specification and links to a new appendix section that explains why ORD Overlay is a dedicated, ORD-opinionated model (multi-format targets, concept-level selectors, ORD identifiers integration, `purpose`/`visibility`, explicit patch actions) and how the two interoperate.
- `sap:core:v1` policy: SAP applications and services MUST use `type: "ord:overlay:v1"` for all published overlays.