### PR TITLE
Add Arazzo workflow support (arazzo-v1, workflow capability, ord:orchestrates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+### Added
+
+- Added [Arazzo Specification](https://www.openapis.org/arazzo-specification) support for describing multi-step API workflows.
+  - New resource definition type `arazzo-v1` on API Resources. Use this when the Arazzo workflow is scoped to a single API.
+  - New standardized Capability type `workflow` with definition type `arazzo-v1` for multi-API workflows. Such capabilities SHOULD use `relatedApiResources` to indicate which APIs the workflow orchestrates.
+  - New `relatedApiResources.relationType` value `ord:orchestrates` to declare that the source resource (e.g. a `workflow` Capability) orchestrates the target API Resource.
+
 ## [1.16.3]
 
 ### Changed

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -2849,6 +2849,18 @@ definitions:
               ORD Overlay file for patching referenced resource definition files.
               For details, see [ORD Overlay](../../spec-v1/interfaces/OrdOverlay).
               The `mediaType` MUST be set to `application/json`.
+          - const: arazzo-v1
+            x-introduced-in-version: "1.16.4"
+            description: |-
+              [Arazzo Specification v1.0.0](https://spec.openapis.org/arazzo/v1.0.0.html) workflow document
+              describing multi-step API interactions.
+              The `mediaType` MUST be set to `application/json` or `application/yaml`.
+
+              Attaching an Arazzo definition to a single API Resource is ONLY appropriate when the
+              workflow is scoped to that specific API. For workflows that span multiple APIs, publish
+              a [Capability](#capability) with `type: "workflow"` and a definition of `type: "arazzo-v1"` instead,
+              and list every covered API via [`relatedApiResources`](#capability_relatedapiresources) with
+              `relationType: "ord:orchestrates"`.
           - const: custom
             description: |-
               If chosen, `customType` MUST be provided.
@@ -3501,6 +3513,16 @@ definitions:
               Capability for SAP Master Data Integration (MDI).
 
               For the capability definitions: `type` MUST ONLY be set to `sap.mdo:mdi-capability-definition:v1`.
+          - const: workflow
+            x-introduced-in-version: "1.16.4"
+            description: |-
+              Standardized capability representing an executable, multi-step workflow that orchestrates
+              one or more APIs. Typically defined via an [Arazzo](https://spec.openapis.org/arazzo/v1.0.0.html)
+              document attached as a capability definition with `type: "arazzo-v1"`.
+
+              Workflow capabilities SHOULD list every API Resource they interact with in
+              [`relatedApiResources`](#capability_relatedapiresources), each with
+              `relationType: "ord:orchestrates"`.
           - const: custom
             description: |-
               If chosen, `customType` MUST be provided.
@@ -3663,6 +3685,14 @@ definitions:
 
               The `mediaType` MUST be set to `application/json`.
               The capability `type` MUST be set to `sap.mdo:mdi-capability:v1`.
+          - const: arazzo-v1
+            x-introduced-in-version: "1.16.4"
+            description: |-
+              [Arazzo Specification v1.0.0](https://spec.openapis.org/arazzo/v1.0.0.html) workflow document
+              describing multi-step API interactions.
+
+              The `mediaType` MUST be set to `application/json` or `application/yaml`.
+              The capability `type` SHOULD be set to `workflow` when the Arazzo workflow spans multiple APIs.
           - const: custom
             description: |-
               If chosen, a custom type MUST be provided via `customType`
@@ -5513,6 +5543,13 @@ definitions:
             description: |-
               The source resource patches one or more definition files of the target resource.
               Used on [ORD Overlay Resources](#overlay) to declare which API or Event resource they patch.
+          - const: "ord:orchestrates"
+            x-introduced-in-version: "1.16.4"
+            description: |-
+              The source resource orchestrates the target API Resource as part of a multi-step workflow.
+              Typically used on [Capabilities](#capability) of `type: "workflow"` (e.g. defined via an
+              [Arazzo](https://spec.openapis.org/arazzo/v1.0.0.html) document) to declare which APIs
+              the workflow invokes.
         examples:
           - "foo.bar:relationName"
     required:

--- a/src/generated/spec/v1/types/Document.ts
+++ b/src/generated/spec/v1/types/Document.ts
@@ -913,7 +913,7 @@ export interface RelatedAPIResource {
    * Defines the semantic meaning of the relationship.
    * If not provided, the relationship has no specific semantics ("related somehow").
    */
-  relationType?: (string | "ord:patches") & string;
+  relationType?: (string | "ord:patches" | "ord:orchestrates") & string;
 }
 /**
  * Defines a relation to an Event Resource (via its ORD ID).
@@ -1001,6 +1001,7 @@ export interface ApiResourceDefinition {
     | "sap-sql-api-definition-v1"
     | "sap-csn-interop-effective-v1"
     | "ord:overlay:v1"
+    | "arazzo-v1"
     | "custom"
   ) &
     string;
@@ -2240,7 +2241,7 @@ export interface Capability {
   /**
    * Type of the Capability
    */
-  type: (string | "sap.mdo:mdi-capability:v1" | "custom") & string;
+  type: (string | "sap.mdo:mdi-capability:v1" | "workflow" | "custom") & string;
   /**
    * If the fixed `type` enum values need to be extended, an arbitrary `customType` can be provided.
    *
@@ -2471,7 +2472,7 @@ export interface CapabilityDefinition {
   /**
    * Type of the capability resource definition
    */
-  type: (string | "sap.mdo:mdi-capability-definition:v1" | "custom") & string;
+  type: (string | "sap.mdo:mdi-capability-definition:v1" | "arazzo-v1" | "custom") & string;
   /**
    * If the fixed `type` enum values need to be extended, an arbitrary `customType` can be provided.
    *


### PR DESCRIPTION
## Summary

Adds support for [Arazzo](https://www.openapis.org/arazzo-specification) multi-step API workflows in ORD.

- **`arazzo-v1` on API Resource `resourceDefinitions`** — for workflows scoped to a single API.
- **`workflow` Capability type** with **`arazzo-v1` capability definition** — for workflows that span multiple APIs. Such capabilities SHOULD list every covered API in `relatedApiResources`.
- **`ord:orchestrates` relationType** — declares that the source resource (e.g. a `workflow` Capability) orchestrates the target API Resource.

Scheduled for the next patch release (1.16.4).