### PR TITLE
Add partOfProducts to package in document-agents.json example

### DIFF
--- a/examples/documents/document-agents.json
+++ b/examples/documents/document-agents.json
@@ -138,7 +138,8 @@
       "shortDescription": "Package containing reference application resources",
       "description": "This package contains all resources related to the ORD reference application including agents and APIs.",
       "version": "1.0.0",
-      "vendor": "sap:vendor:SAP:"
+      "vendor": "sap:vendor:SAP:",
+      "partOfProducts": ["sap:product:sapsuccessfactors:"]
     }
   ]
 }

--- a/examples/documents/document-agents.json
+++ b/examples/documents/document-agents.json
@@ -139,7 +139,7 @@
       "description": "This package contains all resources related to the ORD reference application including agents and APIs.",
       "version": "1.0.0",
       "vendor": "sap:vendor:SAP:",
-      "partOfProducts": ["sap:product:S4HANA_OD:"],
+      "partOfProducts": ["sap:product:S4HANA_OD:"]
     }
   ]
 }

--- a/examples/documents/document-agents.json
+++ b/examples/documents/document-agents.json
@@ -139,7 +139,7 @@
       "description": "This package contains all resources related to the ORD reference application including agents and APIs.",
       "version": "1.0.0",
       "vendor": "sap:vendor:SAP:",
-      "partOfProducts": ["sap:product:sapsuccessfactors:"]
+      "partOfProducts": ["sap:product:S4HANA_OD:"],
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `partOfProducts` to the package in `examples/documents/document-agents.json`, aligning it with the other example documents (`document-1.json`, `document-data-product.json`) where packages declare `partOfProducts`.

## Test plan
- [x] `npm run generate` (via pre-commit hook)