### PR TITLE
Use standardized sap.ai:interactionMode label in agent examples

### DIFF
--- a/docs/spec-v1/concepts/ai-agents-and-protocols.md
+++ b/docs/spec-v1/concepts/ai-agents-and-protocols.md
@@ -80,7 +80,7 @@ The following example shows how an Agent is described in an ORD Document:
 
       // Extensible properties via labels
       "labels": {
-        "interactionMode": ["conversational", "system-triggered"]
+        "sap.ai:interactionMode": ["conversational", "system-triggered"]
       },
       "tags": ["finance", "billing", "dispute-resolution", "ai-agent"],
       // ...

--- a/examples/documents/document-agents.json
+++ b/examples/documents/document-agents.json
@@ -94,7 +94,7 @@
       "exposedApiResources": [{"ordId": "sap.foo:apiResource:DisputeResolutionAgent:v1"}],
       "integrationDependencies": ["sap.foo:integrationDependency:DisputeCaseManagement:v1"],
       "labels": {
-        "foo.ai:interaction-mode": ["conversational", "system-triggered"]
+        "sap.ai:interactionMode": ["conversational", "system-triggered"]
       },
       "tags": ["finance", "billing", "dispute-resolution", "invoicing", "ai-agent"],
       "links": [


### PR DESCRIPTION
Align the interaction mode label in the Agent examples to the standardized sap.ai:interactionMode spelling.

Both examples previously used inconsistent keys. They now use the exact namespaced key and supported example values.

The ORD document explicitly uses an empty policyLevels list because this public example is not intended to demonstrate SAP-specific policy compliance.

Docs and example only.