### PR TITLE
Make shortDescription optional in base spec, governed by policy level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 ### Changed
 
 - Made `shortDescription` optional in the base specification. It is no longer a required property on `Package`, `ApiResource`, `EventResource`, `DataProduct`, and `Product`. This lowers the barrier to adopting ORD, while stricter requirements can still be enforced via policy levels.
-- `sap:base:v1` policy level: `shortDescription` is now governed by resource `visibility`: MUST be provided for `public` resources, RECOMMENDED for `internal` resources, and optional for `private` resources. For `Product`, `shortDescription` MUST always be provided (a Product describes public-facing information).
+- `sap:base:v1` policy level: `shortDescription` is now governed by resource `visibility`: MUST be provided for `public` resources, RECOMMENDED for `internal` resources (MUST if the internal content is to be published to the SAP Business Accelerator Hub), and optional for `private` resources. For `Product`, `shortDescription` MUST always be provided (a Product describes public-facing information).
 
 ## [1.16.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+## [1.17.0]
+
+### Changed
+
+- Made `shortDescription` optional in the base specification. It is no longer a required property on `Package`, `ApiResource`, `EventResource`, `DataProduct`, and `Product`. This lowers the barrier to adopting ORD, while stricter requirements can still be enforced via policy levels.
+- `sap:base:v1` policy level: `shortDescription` is now governed by resource `visibility`: MUST be provided for `public` resources, RECOMMENDED for `internal` resources, and optional for `private` resources. For `Product`, `shortDescription` MUST always be provided (a Product describes public-facing information).
+
 ## [1.16.3]
 
 ### Changed

--- a/docs/spec-extensions/policy-levels/sap-base-v1.md
+++ b/docs/spec-extensions/policy-levels/sap-base-v1.md
@@ -43,6 +43,7 @@ The base ORD specification makes `shortDescription` optional. Under this policy 
 
 - For `public` resources, `shortDescription` MUST be provided.
 - For `internal` resources, `shortDescription` is RECOMMENDED.
+  - It MUST be provided if the internal content is to be published to the SAP Business Accelerator Hub.
 - For `private` resources, `shortDescription` is optional (not consequential).
 
 This applies to all resources that carry a `visibility` (e.g. Package, API Resource, Event Resource, Data Product).

--- a/docs/spec-extensions/policy-levels/sap-base-v1.md
+++ b/docs/spec-extensions/policy-levels/sap-base-v1.md
@@ -37,6 +37,18 @@ Usually SAP applications and services will use the more complete and opinionated
 
 - The vendor of a Package MUST be set and be equal to one of the allowed values: `sap:vendor:SAP:`, `customer:vendor:Customer:`.
 
+### Short Description
+
+The base ORD specification makes `shortDescription` optional. Under this policy level the following applies, based on the resource `visibility`:
+
+- For `public` resources, `shortDescription` MUST be provided.
+- For `internal` resources, `shortDescription` is RECOMMENDED.
+- For `private` resources, `shortDescription` is optional (not consequential).
+
+This applies to all resources that carry a `visibility` (e.g. Package, API Resource, Event Resource, Data Product).
+
+- For `Product`, `shortDescription` MUST be provided. A Product describes public-facing information, so it is always treated as public.
+
 ### Misc Constraints
 
 - Although `Vendor` is technically not validated by a policy level, we need to ensure that within SAP we don't define the SAP vendor multiple times or reference it differently.

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -719,7 +719,6 @@ definitions:
     required:
       - ordId
       - title
-      - shortDescription
       - description
       - version
       - vendor
@@ -1689,7 +1688,6 @@ definitions:
     required:
       - ordId
       - title
-      - shortDescription
       - description
       - version
       - releaseStatus
@@ -1975,7 +1973,6 @@ definitions:
     required:
       - ordId
       - title
-      - shortDescription
       - description
       - version
       - visibility
@@ -2693,7 +2690,6 @@ definitions:
       - type
       - category
       - title
-      - shortDescription
       - description
       - version
       - releaseStatus
@@ -3458,7 +3454,6 @@ definitions:
     required:
       - ordId
       - title
-      - shortDescription
       - vendor
 
   ############################################################################################################

--- a/src/generated/spec/v1/types/Document.ts
+++ b/src/generated/spec/v1/types/Document.ts
@@ -397,7 +397,7 @@ export interface ApiResource {
    * MUST NOT exceed 255 chars.
    * MUST NOT contain line breaks.
    */
-  shortDescription: string;
+  shortDescription?: string;
   /**
    * Full description, notated in [CommonMark](https://spec.commonmark.org/) (Markdown).
    *
@@ -1361,7 +1361,7 @@ export interface EventResource {
    * MUST NOT exceed 255 chars.
    * MUST NOT contain line breaks.
    */
-  shortDescription: string;
+  shortDescription?: string;
   /**
    * Full description, notated in [CommonMark](https://spec.commonmark.org/) (Markdown).
    *
@@ -2579,7 +2579,7 @@ export interface DataProduct {
    * MUST NOT exceed 255 chars.
    * MUST NOT contain line breaks.
    */
-  shortDescription: string;
+  shortDescription?: string;
   /**
    * Full description, notated in [CommonMark](https://spec.commonmark.org/) (Markdown).
    *
@@ -3923,7 +3923,7 @@ export interface Product {
    * MUST NOT exceed 255 chars.
    * MUST NOT contain line breaks.
    */
-  shortDescription: string;
+  shortDescription?: string;
   /**
    * Full description, notated in [CommonMark](https://spec.commonmark.org/) (Markdown).
    *
@@ -4006,7 +4006,7 @@ export interface Package {
    * MUST NOT exceed 255 chars.
    * MUST NOT contain line breaks.
    */
-  shortDescription: string;
+  shortDescription?: string;
   /**
    * Full description, notated in [CommonMark](https://spec.commonmark.org/) (Markdown).
    *

--- a/static/spec-v1/interfaces/ums/MetadataType/apiresource.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/apiresource.yaml
@@ -43,7 +43,6 @@ spec:
     - name: 'shortDescription'
       type: 'string'
       description: "Plain text short description.\n\nMUST NOT exceed 255 chars.\nMUST NOT contain line breaks."
-      mandatory: true
       constraints:
         minLength: 1
         maxLength: 255

--- a/static/spec-v1/interfaces/ums/MetadataType/dataproduct.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/dataproduct.yaml
@@ -43,7 +43,6 @@ spec:
     - name: 'shortDescription'
       type: 'string'
       description: "Plain text short description.\n\nMUST NOT exceed 255 chars.\nMUST NOT contain line breaks."
-      mandatory: true
       constraints:
         minLength: 1
         maxLength: 255

--- a/static/spec-v1/interfaces/ums/MetadataType/eventresource.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/eventresource.yaml
@@ -43,7 +43,6 @@ spec:
     - name: 'shortDescription'
       type: 'string'
       description: "Plain text short description.\n\nMUST NOT exceed 255 chars.\nMUST NOT contain line breaks."
-      mandatory: true
       constraints:
         minLength: 1
         maxLength: 255

--- a/static/spec-v1/interfaces/ums/MetadataType/package.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/package.yaml
@@ -43,7 +43,6 @@ spec:
     - name: 'shortDescription'
       type: 'string'
       description: "Plain text short description.\n\nMUST NOT exceed 255 chars.\nMUST NOT contain line breaks."
-      mandatory: true
       constraints:
         minLength: 1
         maxLength: 255

--- a/static/spec-v1/interfaces/ums/MetadataType/product.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/product.yaml
@@ -38,7 +38,6 @@ spec:
     - name: 'shortDescription'
       type: 'string'
       description: "Plain text short description.\n\nMUST NOT exceed 255 chars.\nMUST NOT contain line breaks."
-      mandatory: true
       constraints:
         minLength: 1
         maxLength: 255


### PR DESCRIPTION
Makes `shortDescription` optional in the base spec, moving the stricter requirement into the `sap:base:v1` policy level. This lowers the barrier to adopting ORD and keeps SAP-specific expectations out of the base specification.

## Changes

- **Base spec**: `shortDescription` is no longer required on `Package`, `ApiResource`, `EventResource`, `DataProduct`, and `Product`.
- **`sap:base:v1` policy level**: `shortDescription` is governed by `visibility`:
  - `public` → MUST be provided
  - `internal` → RECOMMENDED
  - `private` → optional
  - `Product` → MUST always be provided (describes public-facing information)
- CHANGELOG updated (next minor release, 1.17.0).

Generated types and UMS metadata regenerated accordingly (pre-commit hook).
