### PR TITLE
Make partOfPackage optional in base spec, enforced via policy level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+## [1.17.0]
+
+### Changed
+
+- Made the `partOfPackage` assignment optional in the base specification. It is no longer a required property on `ApiResource`, `EventResource`, `EntityType`, `DataProduct`, `Agent`, `Capability`, and `IntegrationDependency`. This lowers the barrier to adopting ORD, while stricter requirements can still be enforced via policy levels.
+- `sap:base:v1` policy level: a Package assignment (`partOfPackage`) is now RECOMMENDED, and MUST be provided when the resource is to be published to the SAP Business Accelerator Hub.
+
 ## [1.16.3]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 ### Changed
 
 - Made the `partOfPackage` assignment optional in the base specification. It is no longer a required property on `ApiResource`, `EventResource`, `EntityType`, `DataProduct`, `Agent`, `Capability`, and `IntegrationDependency`. This lowers the barrier to adopting ORD, while stricter requirements can still be enforced via policy levels.
-- `sap:base:v1` policy level: a Package assignment (`partOfPackage`) is now RECOMMENDED, and MUST be provided when the resource is to be published to the SAP Business Accelerator Hub.
+- `sap:base:v1` policy level: a Package assignment (`partOfPackage`) MUST be provided if the resource is `public` or is to be published to the SAP Business Accelerator Hub (which MAY also apply to `internal` resources); otherwise it is RECOMMENDED.
 
 ## [1.16.3]
 

--- a/docs/spec-extensions/policy-levels/sap-base-v1.md
+++ b/docs/spec-extensions/policy-levels/sap-base-v1.md
@@ -37,6 +37,13 @@ Usually SAP applications and services will use the more complete and opinionated
 
 - The vendor of a Package MUST be set and be equal to one of the allowed values: `sap:vendor:SAP:`, `customer:vendor:Customer:`.
 
+### Package Assignment
+
+The base ORD specification makes the `partOfPackage` assignment optional. Under this policy level the following applies:
+
+- Resources SHOULD be assigned to a Package via `partOfPackage`.
+- A Package assignment MUST be provided if the resource is to be published to the SAP Business Accelerator Hub.
+
 ### Misc Constraints
 
 - Although `Vendor` is technically not validated by a policy level, we need to ensure that within SAP we don't define the SAP vendor multiple times or reference it differently.

--- a/docs/spec-extensions/policy-levels/sap-base-v1.md
+++ b/docs/spec-extensions/policy-levels/sap-base-v1.md
@@ -41,8 +41,10 @@ Usually SAP applications and services will use the more complete and opinionated
 
 The base ORD specification makes the `partOfPackage` assignment optional. Under this policy level the following applies:
 
-- Resources SHOULD be assigned to a Package via `partOfPackage`.
-- A Package assignment MUST be provided if the resource is to be published to the SAP Business Accelerator Hub.
+- A Package assignment (`partOfPackage`) MUST be provided if either:
+  - the resource has `visibility` `public`, or
+  - the resource is to be published to the SAP Business Accelerator Hub (this MAY also apply to `internal` resources).
+- Otherwise, a Package assignment SHOULD be provided.
 
 ### Misc Constraints
 

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -1015,7 +1015,8 @@ definitions:
 
           MUST be a valid reference to a [Package](#package) ORD ID.
 
-          Every resource MUST be part of one package.
+          A resource MAY be part of a Package.
+          Some policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details.
         examples:
           - "sap.xref:package:SomePackage:v1"
 
@@ -1695,7 +1696,6 @@ definitions:
       - releaseStatus
       - apiProtocol
       - visibility
-      - partOfPackage
     additionalProperties: false
 
   ############################################################################################################
@@ -1979,7 +1979,6 @@ definitions:
       - description
       - version
       - visibility
-      - partOfPackage
       - releaseStatus
     x-recommended:
       - lastUpdate
@@ -2205,7 +2204,6 @@ definitions:
       - title
       - version
       - visibility
-      - partOfPackage
       - releaseStatus
     x-recommended:
       - lastUpdate
@@ -2698,7 +2696,6 @@ definitions:
       - version
       - releaseStatus
       - visibility
-      - partOfPackage
       - responsible
       - outputPorts
     x-recommended:
@@ -3235,7 +3232,6 @@ definitions:
       - version
       - releaseStatus
       - visibility
-      - partOfPackage
     x-recommended:
       - lastUpdate
 
@@ -3635,7 +3631,6 @@ definitions:
       - version
       - releaseStatus
       - visibility
-      - partOfPackage
     x-recommended:
       - lastUpdate
 
@@ -3840,7 +3835,6 @@ definitions:
       - version
       - releaseStatus
       - visibility
-      - partOfPackage
       - mandatory
 
   ############################################################################################################
@@ -5870,5 +5864,4 @@ definitions:
       - version
       - visibility
       - releaseStatus
-      - partOfPackage
     additionalProperties: true

--- a/src/generated/spec/v1/types/Document.ts
+++ b/src/generated/spec/v1/types/Document.ts
@@ -418,9 +418,10 @@ export interface ApiResource {
    *
    * MUST be a valid reference to a [Package](#package) ORD ID.
    *
-   * Every resource MUST be part of one package.
+   * A resource MAY be part of a Package.
+   * Some policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details.
    */
-  partOfPackage: string;
+  partOfPackage?: string;
   /**
    * Defines which groups the resource is assigned to.
    *
@@ -1382,9 +1383,10 @@ export interface EventResource {
    *
    * MUST be a valid reference to a [Package](#package) ORD ID.
    *
-   * Every resource MUST be part of one package.
+   * A resource MAY be part of a Package.
+   * Some policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details.
    */
-  partOfPackage: string;
+  partOfPackage?: string;
   /**
    * Defines which groups the resource is assigned to.
    *
@@ -1934,9 +1936,10 @@ export interface EntityType {
    *
    * MUST be a valid reference to a [Package](#package) ORD ID.
    *
-   * Every resource MUST be part of one package.
+   * A resource MAY be part of a Package.
+   * Some policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details.
    */
-  partOfPackage: string;
+  partOfPackage?: string;
   /**
    * Defines which groups the resource is assigned to.
    *
@@ -2283,9 +2286,10 @@ export interface Capability {
    *
    * MUST be a valid reference to a [Package](#package) ORD ID.
    *
-   * Every resource MUST be part of one package.
+   * A resource MAY be part of a Package.
+   * Some policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details.
    */
-  partOfPackage: string;
+  partOfPackage?: string;
   /**
    * Defines which groups the resource is assigned to.
    *
@@ -2600,9 +2604,10 @@ export interface DataProduct {
    *
    * MUST be a valid reference to a [Package](#package) ORD ID.
    *
-   * Every resource MUST be part of one package.
+   * A resource MAY be part of a Package.
+   * Some policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details.
    */
-  partOfPackage: string;
+  partOfPackage?: string;
   /**
    * Defines which groups the resource is assigned to.
    *
@@ -3041,9 +3046,10 @@ export interface Agent {
    *
    * MUST be a valid reference to a [Package](#package) ORD ID.
    *
-   * Every resource MUST be part of one package.
+   * A resource MAY be part of a Package.
+   * Some policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details.
    */
-  partOfPackage: string;
+  partOfPackage?: string;
   /**
    * Defines which groups the resource is assigned to.
    *
@@ -3563,9 +3569,10 @@ export interface IntegrationDependency {
    *
    * MUST be a valid reference to a [Package](#package) ORD ID.
    *
-   * Every resource MUST be part of one package.
+   * A resource MAY be part of a Package.
+   * Some policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details.
    */
-  partOfPackage: string;
+  partOfPackage?: string;
   /**
    * Defines which groups the resource is assigned to.
    *

--- a/static/spec-v1/interfaces/ums/AbstractMetadataType/ordresource.yaml
+++ b/static/spec-v1/interfaces/ums/AbstractMetadataType/ordresource.yaml
@@ -54,8 +54,7 @@ spec:
         minLength: 1
     - name: 'partOfPackage_ID'
       type: 'guid'
-      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
-      mandatory: true
+      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nA resource MAY be part of a Package.\nSome policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details."
       constraints:
         maxLength: 255
         pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(package):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
@@ -133,8 +132,7 @@ spec:
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       propertyBased: true
       managedByProperty: 'partOfPackage_ID'
-      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
-      mandatory: true
+      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nA resource MAY be part of a Package.\nSome policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details."
     - propertyName: 'partOfGroups'
       relatedTypeName: 'Group'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'

--- a/static/spec-v1/interfaces/ums/MetadataType/agent.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/agent.yaml
@@ -58,8 +58,7 @@ spec:
         minLength: 1
     - name: 'partOfPackage_ID'
       type: 'guid'
-      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
-      mandatory: true
+      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nA resource MAY be part of a Package.\nSome policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details."
       constraints:
         maxLength: 255
         pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(package):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
@@ -218,8 +217,7 @@ spec:
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       propertyBased: true
       managedByProperty: 'partOfPackage_ID'
-      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
-      mandatory: true
+      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nA resource MAY be part of a Package.\nSome policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details."
       reverseRelation:
         relationPropertyName: 'agents'
     - propertyName: 'partOfGroups'

--- a/static/spec-v1/interfaces/ums/MetadataType/apiresource.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/apiresource.yaml
@@ -60,8 +60,7 @@ spec:
         minLength: 1
     - name: 'partOfPackage_ID'
       type: 'guid'
-      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
-      mandatory: true
+      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nA resource MAY be part of a Package.\nSome policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details."
       constraints:
         maxLength: 255
         pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(package):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
@@ -386,8 +385,7 @@ spec:
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       propertyBased: true
       managedByProperty: 'partOfPackage_ID'
-      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
-      mandatory: true
+      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nA resource MAY be part of a Package.\nSome policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details."
       reverseRelation:
         relationPropertyName: 'apiResources'
     - propertyName: 'partOfGroups'

--- a/static/spec-v1/interfaces/ums/MetadataType/capability.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/capability.yaml
@@ -68,8 +68,7 @@ spec:
         minLength: 1
     - name: 'partOfPackage_ID'
       type: 'guid'
-      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
-      mandatory: true
+      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nA resource MAY be part of a Package.\nSome policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details."
       constraints:
         maxLength: 255
         pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(package):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
@@ -217,8 +216,7 @@ spec:
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       propertyBased: true
       managedByProperty: 'partOfPackage_ID'
-      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
-      mandatory: true
+      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nA resource MAY be part of a Package.\nSome policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details."
       reverseRelation:
         relationPropertyName: 'capabilities'
     - propertyName: 'partOfGroups'

--- a/static/spec-v1/interfaces/ums/MetadataType/dataproduct.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/dataproduct.yaml
@@ -60,8 +60,7 @@ spec:
         minLength: 1
     - name: 'partOfPackage_ID'
       type: 'guid'
-      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
-      mandatory: true
+      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nA resource MAY be part of a Package.\nSome policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details."
       constraints:
         maxLength: 255
         pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(package):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
@@ -263,8 +262,7 @@ spec:
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       propertyBased: true
       managedByProperty: 'partOfPackage_ID'
-      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
-      mandatory: true
+      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nA resource MAY be part of a Package.\nSome policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details."
       reverseRelation:
         relationPropertyName: 'dataProducts'
     - propertyName: 'partOfGroups'

--- a/static/spec-v1/interfaces/ums/MetadataType/entitytype.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/entitytype.yaml
@@ -59,8 +59,7 @@ spec:
         minLength: 1
     - name: 'partOfPackage_ID'
       type: 'guid'
-      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
-      mandatory: true
+      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nA resource MAY be part of a Package.\nSome policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details."
       constraints:
         maxLength: 255
         pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(package):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
@@ -248,8 +247,7 @@ spec:
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       propertyBased: true
       managedByProperty: 'partOfPackage_ID'
-      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
-      mandatory: true
+      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nA resource MAY be part of a Package.\nSome policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details."
       reverseRelation:
         relationPropertyName: 'entityTypes'
     - propertyName: 'partOfGroups'

--- a/static/spec-v1/interfaces/ums/MetadataType/eventresource.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/eventresource.yaml
@@ -60,8 +60,7 @@ spec:
         minLength: 1
     - name: 'partOfPackage_ID'
       type: 'guid'
-      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
-      mandatory: true
+      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nA resource MAY be part of a Package.\nSome policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details."
       constraints:
         maxLength: 255
         pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(package):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
@@ -368,8 +367,7 @@ spec:
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       propertyBased: true
       managedByProperty: 'partOfPackage_ID'
-      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
-      mandatory: true
+      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nA resource MAY be part of a Package.\nSome policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details."
       reverseRelation:
         relationPropertyName: 'eventResources'
     - propertyName: 'partOfGroups'

--- a/static/spec-v1/interfaces/ums/MetadataType/integrationdependency.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/integrationdependency.yaml
@@ -53,8 +53,7 @@ spec:
         minLength: 1
     - name: 'partOfPackage_ID'
       type: 'guid'
-      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
-      mandatory: true
+      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nA resource MAY be part of a Package.\nSome policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details."
       constraints:
         maxLength: 255
         pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(package):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
@@ -272,8 +271,7 @@ spec:
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       propertyBased: true
       managedByProperty: 'partOfPackage_ID'
-      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
-      mandatory: true
+      description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nA resource MAY be part of a Package.\nSome policy levels or ORD consumers (e.g. aggregators that navigate resources via Packages) require a Package assignment. See the applicable [policy level](../../spec-extensions/policy-levels/) for details."
       reverseRelation:
         relationPropertyName: 'integrationDependencies'
     - propertyName: 'partOfGroups'


### PR DESCRIPTION
Makes the `partOfPackage` assignment optional in the base spec, moving the requirement into the `sap:base:v1` policy level. Continues the effort to make ORD lighter to adopt and less opinionated.

## ⚠️ This change is controversial

Making Package assignment optional is a trade-off:

- **Pro (providers):** Removing the mandatory Package assignment simplifies ORD Providers. Not every provider benefits from modelling Packages, and forcing it raises the barrier to adopting ORD.
- **Con (consumers/aggregators):** Some consumers and aggregators (e.g. the SAP Business Accelerator Hub) rely on Package-based discovery and navigation of resources. If Packages become optional in the base spec, those consumers can no longer assume every resource has one.

The resolution: the requirement is **not removed, it is moved to a policy level**. Providers that publish to a consumer relying on Packages must satisfy that consumer's policy level, which enforces the assignment.

## Changes

- **Base spec:** `partOfPackage` is no longer required on `ApiResource`, `EventResource`, `EntityType`, `DataProduct`, `Agent`, `Capability`, and `IntegrationDependency`. The property description no longer states "Every resource MUST be part of one package."
- **`sap:base:v1` policy level:** a Package assignment is RECOMMENDED, and MUST be provided when the resource is to be published to the SAP Business Accelerator Hub.
- CHANGELOG updated (next minor release, 1.17.0).

Generated types and UMS metadata regenerated accordingly (pre-commit hook).

## Open questions for reviewers

Opened as a **draft** to invite discussion before merge.

1. Is `sap:base:v1` the right level for the enforcement, or should it live in `sap:core:v1` (where the other Business Accelerator Hub rules sit)?
2. For the non-MUST case, should we keep the `SHOULD`/RECOMMENDED at all, or drop it entirely? I.e. `partOfPackage` MUST be set only if the resource is `public` or is published to BAH, and otherwise is simply **not enforced** (no RECOMMENDED).

