### PR TITLE
Add Schema as a top-level concept (beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+### Added
+
+- Added **`Schema`** as a new, lightweight top-level concept (**beta**). A Schema describes the concrete structure of a data object (e.g. a DTO, an event payload, an API request/response model, or a document/declarative-config contract such as a Kubernetes CRD), described with formats such as JSON Schema, CSN Interop, Avro, Protobuf, or XSD. It is distinct from `EntityType` (the conceptual domain model or business term): a Schema is a concrete, physical representation of an Entity Type. See the [Schema](https://open-resource-discovery.org/spec-v1/concepts/schema) concept page.
+  - Required: `ordId`, `title`, `version`, `releaseStatus`, `visibility`. `partOfPackage` is optional.
+  - Added optional `compatibility` mode (`none`/`backward`/`forward`/`full`).
+  - Added `SchemaDefinition` with an extensible `type` enum: global industry-standard formats as bare consts (`json-schema-v7`, `json-schema-v2020-12`, `avro-v1`, `protobuf-v3`, `xsd-v1`, `sap-csn-interop-effective-v1`), plus any valid Specification ID or `custom`.
+  - Added `SchemaEntityTypeRelation` (`{ordId, relationType}`, extensible; `ord:represents` / `ord:partial-representation`) as the value of `Schema.relatedEntityTypes` (direction: Schema → Entity Type).
+  - Added `schemas` array to the ORD Document root.
+- Added **`relatedSchemas`** (beta) to `ApiResource`, `EventResource`, and `Capability` to reference related Schemas. Modeled as a `RelatedSchema` object (`{ordId, relationType}`) with an extensible `relationType` (`ord:exposes` for schemas contained in an API contract, `ord:payload` for an event payload schema).
+
 ## [1.16.3]
 
 ### Changed

--- a/docs/spec-v1/concepts/schema.md
+++ b/docs/spec-v1/concepts/schema.md
@@ -1,0 +1,62 @@
+---
+sidebar_position: 6
+description: Detailed explanation of the Schema concept.
+---
+
+# Schema
+
+:::info Beta
+The **Schema** concept is in **beta**. Its properties and relationships MAY change based on adoption and feedback.
+:::
+
+## Summary
+
+A **Schema** describes the concrete structure of a data object, for example a Data Transfer Object (DTO), an event payload, or an API request/response model.
+A Schema can be described with formats such as [JSON Schema](https://json-schema.org/), [CSN Interop](https://sap.github.io/csn-interop-specification/), [Apache Avro](https://avro.apache.org/), [Protocol Buffers](https://protobuf.dev/), or XSD.
+
+Schemas can also describe the contract of **whole documents or declarative configuration objects**, such as [Kubernetes Custom Resource Definitions (CRDs)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/). The ORD specification itself is such an example: it publishes a [JSON Schema for ORD Documents](https://open-resource-discovery.org/spec-v1/interfaces/Document.schema.json).
+
+Schemas are lightweight to describe (similar to [Capabilities](../interfaces/Document#capability)) and are meant to be **reusable** and **shared**.
+
+See also: [Schema interface](../interfaces/Document#schema).
+
+## Schema vs. Entity Type
+
+ORD distinguishes between the *conceptual* and the *physical* view of data:
+
+| | [Entity Type](../interfaces/Document#entity-type) | [Schema](../interfaces/Document#schema) |
+|---|---|---|
+| Represents | conceptual domain model or business term (a "noun") | concrete serialization structure ("how the data is shaped on the wire") |
+| Answers | *what it means* | *how it is shaped* |
+| Example | `sap.odm:entityType:BusinessPartner:v1` | `sap.foo:schema:BusinessPartner:v1` |
+
+An Entity Type is more than just data: it captures business semantics and, depending on the API and protocol, the same Entity Type may have **different physical representations** (and therefore different Schemas). A Schema is one such physical representation of an Entity Type.
+
+A Schema MAY reference the Entity Type(s) it represents via `relatedEntityTypes`, providing traceability between the conceptual model and its physical representation. The direction is always **Schema → Entity Type** (a Schema points to the concept it represents); the inverse is derived automatically.
+
+## Relationship to APIs and Events
+
+Resources link to Schemas via a `relatedSchemas` list of `{ordId, relationType}` entries. The optional `relationType` is an extensible [Concept ID](../index.md#concept-id) that qualifies the nature of the relationship:
+
+- **API resources expose many Schemas.** An API contract (e.g. OpenAPI or AsyncAPI) typically contains many Schemas as its request, response, or payload structures (`relationType: ord:exposes`).
+- **Event resources reference payload Schemas.** Each event typically references one payload Schema, often published in a schema registry, e.g. Confluent Schema Registry or CNCF xRegistry (`relationType: ord:payload`).
+- **Capabilities can relate to Schemas** as well, via the same `relatedSchemas` field.
+- **Schemas are reusable.** Because a Schema is a top-level resource with its own ORD ID, the same Schema can be related from several APIs, Events, and Capabilities.
+
+## Describing the Schema
+
+The machine-readable schema definition file(s) are referenced via `definitions`, following the same mechanism as API and Event resource definitions (`type` + `mediaType` + `url`).
+
+The `type` is an **extensible enum**. Global industry-standard formats are standardized by ORD as bare (unprefixed) values (`json-schema-v7`, `json-schema-v2020-12`, `avro-v1`, `protobuf-v3`, `xsd-v1`, `sap-csn-interop-effective-v1`), consistent with existing definition types like `openapi-v3` and `asyncapi-v2`. Vendor- or organization-specific formats use a namespace-prefixed [Specification ID](../index.md#specification-id), or `custom` + `customType`.
+
+## Versioning and compatibility
+
+A Schema carries a semantic `version`. It MAY additionally declare an optional `compatibility` mode (`none`, `backward`, `forward`, `full`) to express its schema-evolution guarantees, mirroring the compatibility modes found in common schema registries.
+
+## Current Status
+
+This concept is in **beta**. In particular, the following are open for feedback:
+
+- The exact set of `SchemaDefinition` `type` enum values.
+- Whether Schema-to-Schema composition references are needed.
+- Whether `compatibility` should be extended to transitive variants.

--- a/examples/documents/document-schemas.json
+++ b/examples/documents/document-schemas.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://open-resource-discovery.org/spec-v1/interfaces/Document.schema.json",
+  "openResourceDiscovery": "1.17",
+  "description": "Example for Schemas: reusable data contracts referenced by APIs and Events, and related to Entity Types.",
+  "policyLevels": ["sap:core:v1"],
+  "packages": [
+    {
+      "ordId": "sap.foo:package:SchemaExample:v1",
+      "title": "Schema Example Package",
+      "shortDescription": "Example package showcasing the Schema concept.",
+      "description": "This package bundles an API, an Event, and the Schemas they expose.",
+      "version": "1.0.0",
+      "policyLevels": ["sap:core:v1"],
+      "vendor": "sap:vendor:SAP:"
+    }
+  ],
+  "entityTypes": [
+    {
+      "ordId": "sap.odm:entityType:BusinessPartner:v1",
+      "localId": "BusinessPartner",
+      "level": "aggregate",
+      "title": "Business Partner",
+      "shortDescription": "A person, an organization, or a group of persons or organizations.",
+      "description": "A business partner is a person, an organization, or a group of persons or organizations in which a company has a business interest.",
+      "version": "1.0.0",
+      "lastUpdate": "2026-07-31T15:30:04+00:00",
+      "partOfPackage": "sap.foo:package:SchemaExample:v1",
+      "visibility": "public",
+      "releaseStatus": "active"
+    }
+  ],
+  "schemas": [
+    {
+      "ordId": "sap.foo:schema:BusinessPartner:v1",
+      "localId": "BusinessPartner",
+      "title": "Business Partner (JSON representation)",
+      "shortDescription": "JSON Schema representation of a Business Partner.",
+      "description": "The physical JSON Schema data contract for a Business Partner as exposed via the REST API.",
+      "version": "1.0.0",
+      "lastUpdate": "2026-07-31T15:30:04+00:00",
+      "partOfPackage": "sap.foo:package:SchemaExample:v1",
+      "visibility": "public",
+      "releaseStatus": "active",
+      "compatibility": "backward",
+      "relatedEntityTypes": [
+        {
+          "ordId": "sap.odm:entityType:BusinessPartner:v1",
+          "relationType": "ord:represents"
+        }
+      ],
+      "definitions": [
+        {
+          "type": "json-schema-v2020-12",
+          "mediaType": "application/json",
+          "url": "/schemas/businessPartner.schema.json",
+          "accessStrategies": [{ "type": "open" }]
+        }
+      ]
+    },
+    {
+      "ordId": "sap.foo:schema:BusinessPartnerCreated:v1",
+      "localId": "BusinessPartnerCreated",
+      "title": "Business Partner Created (Event Payload)",
+      "shortDescription": "Avro payload schema for the BusinessPartnerCreated event.",
+      "description": "The physical event payload data contract, published in a schema registry.",
+      "version": "1.0.0",
+      "lastUpdate": "2026-07-31T15:30:04+00:00",
+      "partOfPackage": "sap.foo:package:SchemaExample:v1",
+      "visibility": "public",
+      "releaseStatus": "active",
+      "compatibility": "full",
+      "relatedEntityTypes": [
+        {
+          "ordId": "sap.odm:entityType:BusinessPartner:v1",
+          "relationType": "ord:partial-representation"
+        }
+      ],
+      "definitions": [
+        {
+          "type": "avro-v1",
+          "mediaType": "application/json",
+          "url": "/schemas/businessPartnerCreated.avsc",
+          "accessStrategies": [{ "type": "open" }]
+        }
+      ]
+    }
+  ],
+  "apiResources": [
+    {
+      "ordId": "sap.foo:apiResource:BusinessPartnerApi:v1",
+      "title": "Business Partner API",
+      "shortDescription": "REST API for managing Business Partners.",
+      "description": "Provides CRUD operations for Business Partners. Exposes (contains) the Business Partner Schema.",
+      "version": "1.0.0",
+      "visibility": "public",
+      "partOfPackage": "sap.foo:package:SchemaExample:v1",
+      "releaseStatus": "active",
+      "apiProtocol": "rest",
+      "relatedSchemas": [{ "ordId": "sap.foo:schema:BusinessPartner:v1", "relationType": "ord:exposes" }],
+      "resourceDefinitions": [
+        {
+          "type": "openapi-v3",
+          "mediaType": "application/json",
+          "url": "/apis/businessPartner/openapi.json",
+          "accessStrategies": [{ "type": "open" }]
+        }
+      ]
+    }
+  ],
+  "eventResources": [
+    {
+      "ordId": "sap.foo:eventResource:BusinessPartnerEvents:v1",
+      "title": "Business Partner Events",
+      "shortDescription": "Events emitted for Business Partner lifecycle changes.",
+      "description": "Event resource emitting BusinessPartnerCreated and related events. References the payload Schema.",
+      "version": "1.0.0",
+      "visibility": "public",
+      "partOfPackage": "sap.foo:package:SchemaExample:v1",
+      "releaseStatus": "active",
+      "relatedSchemas": [{ "ordId": "sap.foo:schema:BusinessPartnerCreated:v1", "relationType": "ord:payload" }],
+      "resourceDefinitions": [
+        {
+          "type": "asyncapi-v2",
+          "mediaType": "application/json",
+          "url": "/events/businessPartner/asyncapi.json",
+          "accessStrategies": [{ "type": "open" }]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -13,6 +13,7 @@ x-property-order:
   - EventResource
   - EntityType
   - Capability
+  - Schema
   - DataProduct
   - Agent
   - IntegrationDependency
@@ -59,6 +60,7 @@ properties:
       - "1.14"
       - "1.15"
       - "1.16"
+      - "1.17"
     examples:
       - "1.16"
 
@@ -261,6 +263,19 @@ properties:
     x-introduced-in-version: "1.4.0"
     items:
       $ref: "#/definitions/Capability"
+
+  schemas:
+    type: array
+    description: |-
+      Array of all Schemas that are described in this ORD document.
+
+      A Schema describes the concrete structure of a data object (e.g. a DTO, an event payload,
+      or an API request/response model), described with formats such as JSON Schema, CSN Interop,
+      Avro, Protobuf, or XSD.
+    x-introduced-in-version: "1.17.0"
+    x-feature-status: beta
+    items:
+      $ref: "#/definitions/Schema"
 
   dataProducts:
     type: array
@@ -1607,6 +1622,20 @@ definitions:
           - [{ "ordId": "sap.odm:entityType:WorkforcePerson:v1" }]
           - [{ "ordId": "sap.sm:entityType:PurchaseOrderItem:v1" }, { "ordId": "sap.sm:entityType:BusinessPartner:v1" }]
 
+      relatedSchemas: &relatedSchemas
+        type: array
+        x-introduced-in-version: "1.17.0"
+        x-feature-status: beta
+        description: |-
+          Optional list of related [Schemas](#schema).
+
+          An API contract typically exposes (contains) many Schemas as its request/response or payload structures.
+          Use the `relationType` (e.g. `ord:exposes`) to qualify the relationship.
+        items:
+          $ref: "#/definitions/RelatedSchema"
+        examples:
+          - [{ "ordId": "sap.foo:schema:BusinessPartner:v1", "relationType": "ord:exposes" }]
+
       # Additional links and extensibility info
 
       apiResourceLinks:
@@ -1918,6 +1947,16 @@ definitions:
 
       exposedEntityTypes:
         <<: *exposedEntityTypes
+
+      relatedSchemas:
+        <<: *relatedSchemas
+        description: |-
+          Optional list of related [Schemas](#schema).
+
+          An Event resource typically references one payload Schema per event (often published in a schema registry).
+          Use the `relationType` (e.g. `ord:payload`) to qualify the relationship.
+        examples:
+          - [{ "ordId": "sap.foo:schema:BusinessPartnerCreated:v1", "relationType": "ord:payload" }]
 
       eventResourceLinks:
         type: array
@@ -3605,6 +3644,9 @@ definitions:
         examples:
           - [{ "ordId": "sap.foo:capability:baseExtensibility:v1", "relationType": "foo.bar:relationName" }]
 
+      relatedSchemas:
+        <<: *relatedSchemas
+
       definitions:
         <<: *resourceDefinitions
         items:
@@ -3696,6 +3738,287 @@ definitions:
       - type
       - mediaType
       - url
+
+  ############################################################################################################
+
+  Schema:
+    type: object
+    title: Schema
+    x-ums-type: root
+    x-introduced-in-version: "1.17.0"
+    x-feature-status: beta
+    x-ums-implements: "#/definitions/OrdResource"
+    description: |-
+      A Schema describes the concrete structure of a data object, e.g. a Data Transfer Object (DTO),
+      an event payload, or an API request/response model.
+      A Schema can be described with formats such as JSON Schema, CSN Interop, Avro, Protobuf, or XSD.
+
+      Schemas can also describe the contract of whole documents or declarative configuration objects,
+      e.g. Kubernetes Custom Resource Definitions (CRDs). The ORD specification itself is such an example:
+      it publishes a JSON Schema that describes the structure of ORD Documents.
+
+      Unlike an [Entity Type](#entity-type), which represents a conceptual domain model or a business term
+      (a "noun"), a Schema describes the concrete serialization structure ("how the data is shaped on the wire").
+      A Schema MAY reference the Entity Type(s) it realizes via `relatedEntityTypes`, providing traceability
+      between the conceptual model and its physical representation.
+
+      Schemas are lightweight to describe (similar to [Capabilities](#capability)) and are meant to be reusable:
+      API resources typically expose (contain) many Schemas, while Event resources typically reference one payload
+      Schema each, often published in a schema registry. A Schema MAY also stand on its own (e.g. a document
+      contract), in which case it need not be exposed by any API or Event.
+
+      Please note that this concept is in beta and MAY be changed or removed at the provider's discretion.
+    properties:
+      ordId:
+        <<: *ordId
+        pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):(schema):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+        examples:
+          - "sap.foo:schema:BusinessPartnerCreated:v1"
+
+      localId:
+        <<: *localId
+
+      correlationIds:
+        <<: *correlationIds
+
+      title:
+        <<: *title
+        examples:
+          - Business Partner Created (Event Payload)
+
+      shortDescription:
+        <<: *shortDescription
+
+      description:
+        type: string
+        minLength: 1
+        description: *descriptionText
+
+      aiHint:
+        <<: *aiHint
+        examples: []
+
+      partOfPackage:
+        # NOTE: Optional for Schema (deliberately lighter than most ORD resources).
+        <<: *partOfPackage
+        x-ums-reverse-relationship:
+          propertyName: schemas
+          description: |-
+            The Schemas that are part of the given Package.
+          min: 0
+          max: "*"
+
+      partOfGroups:
+        <<: *partOfGroups
+        x-ums-reverse-relationship:
+          propertyName: schemaMembers
+          description: |-
+            The Schemas that are part of the given Group.
+
+      version:
+        <<: *version
+
+      lastUpdate:
+        <<: *lastUpdate
+
+      visibility:
+        <<: *visibility
+
+      releaseStatus:
+        <<: *releaseStatus
+
+      compatibility:
+        type: string
+        description: |-
+          Optional schema evolution / compatibility mode, describing how future versions of this Schema
+          are allowed to change relative to prior versions.
+
+          This mirrors the compatibility modes found in schema registries (e.g. Confluent, AWS Glue, CNCF xRegistry).
+        enum:
+          - none
+          - backward
+          - forward
+          - full
+        examples:
+          - backward
+
+      relatedEntityTypes:
+        type: array
+        description: |-
+          Optional list of [Entity Type](#entity-type) Resources that this Schema represents / serializes.
+
+          A Schema is a concrete, physical data contract (representation) for an Entity Type.
+          The same Entity Type MAY have several Schemas as representations, depending on the API,
+          protocol, or serialization format that exposes it. Use `relationType` to further qualify
+          the relationship where useful.
+        items:
+          $ref: "#/definitions/SchemaEntityTypeRelation"
+        examples:
+          - [{ "ordId": "sap.odm:entityType:BusinessPartner:v1", "relationType": "ord:represents" }]
+
+      definitions:
+        <<: *resourceDefinitions
+        items:
+          $ref: "#/definitions/SchemaDefinition"
+
+      links:
+        <<: *links
+        description: |-
+          Generic Links with arbitrary meaning and content.
+
+      tags:
+        <<: *tags
+
+      labels:
+        <<: *labels
+
+      documentationLabels:
+        <<: *documentationLabels
+
+      systemInstanceAware:
+        <<: *systemInstanceAware
+
+    additionalProperties: false
+    required:
+      - ordId
+      - title
+      - version
+      - releaseStatus
+      - visibility
+    x-recommended:
+      - lastUpdate
+      - partOfPackage
+
+  ############################################################################################################
+
+  SchemaDefinition:
+    type: object
+    title: Schema Definition
+    x-introduced-in-version: "1.17.0"
+    x-feature-status: beta
+    x-ums-type: "custom"
+    description: |-
+      Link and categorization of a machine-readable schema definition.
+    properties:
+      type:
+        description: |-
+          Type of the schema definition.
+
+          This is an extensible enum. Global industry-standard schema formats are standardized by ORD as bare
+          (unprefixed) values, consistent with existing resource definition types such as `openapi-v3` or
+          `asyncapi-v2`. Formats that are specific to a vendor or organization use a namespace-prefixed
+          [Specification ID](../index.md#specification-id) (e.g. `sap-csn-interop-effective-v1` for CSN Interop).
+        type: string
+        anyOf:
+          - type: string
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+            description: |-
+              Any valid [Specification ID](../index.md#specification-id).
+          - const: "json-schema-v7"
+            description: |-
+              [JSON Schema](https://json-schema.org/) draft-07.
+          - const: "json-schema-v2020-12"
+            description: |-
+              [JSON Schema](https://json-schema.org/) draft 2020-12.
+          - const: "avro-v1"
+            description: |-
+              [Apache Avro](https://avro.apache.org/) schema (v1.x).
+          - const: "protobuf-v3"
+            description: |-
+              [Protocol Buffers](https://protobuf.dev/) schema (proto3).
+          - const: "xsd-v1"
+            description: |-
+              [XML Schema Definition](https://www.w3.org/XML/Schema) (XSD 1.x).
+          - const: "sap-csn-interop-effective-v1"
+            description: |-
+              [CSN Interop Effective](https://sap.github.io/csn-interop-specification/) is a standardized and interoperable [CSN](https://cap.cloud.sap/docs/cds/csn) export, used to describe [CDS](https://cap.cloud.sap/docs/cds/) models.
+
+              It is usually used to describe conceptual models (Entity Types), but with a known mapping, it can double as a description of the actual data / interface schema as well.
+
+              The `mediaType` MUST be set to `application/json`.
+          - const: custom
+            description: |-
+              If chosen, a custom type MUST be provided via `customType`.
+        examples:
+          - "json-schema-v2020-12"
+
+      customType:
+        <<: *customType
+
+      mediaType:
+        <<: *mediaType
+
+      url:
+        <<: *resourceDefinitionUrl
+        examples:
+          - /schemas/businessPartnerCreated.schema.json
+
+      accessStrategies:
+        <<: *accessStrategies
+
+      visibility:
+        <<: *definitionVisibility
+
+      purpose:
+        <<: *resourceDefinitionPurpose
+
+    additionalProperties: false
+    required:
+      - type
+      - mediaType
+      - url
+
+  ############################################################################################################
+
+  SchemaEntityTypeRelation:
+    title: Schema Entity Type Relation
+    x-introduced-in-version: "1.17.0"
+    x-feature-status: beta
+    x-ums-type: "embedded"
+    type: object
+    description: |-
+      Defines the relation between a [Schema](#schema) and an [Entity Type](#entity-type) (via its ORD ID).
+
+      A Schema is a concrete, physical representation (data contract) of an Entity Type.
+    properties:
+      ordId:
+        <<: *ordId
+        pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):(entityType):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+        x-association-target:
+          - "#/definitions/EntityType/ordId"
+        x-ums-reverse-relationship:
+          propertyName: schemas
+          description: |-
+            Schemas that materialize / serialize the given Entity Type.
+          min: 0
+          max: "*"
+        examples:
+          - "sap.odm:entityType:BusinessPartner:v1"
+      relationType:
+        type: string
+        description: |-
+          Optional type of the relationship, which defines a stricter semantic of what the relationship implies.
+
+          If not provided, the relationship type has no specific semantics; the Schema is "a representation of"
+          the referenced Entity Type.
+
+          MUST be a valid [Concept ID](../index.md#concept-id).
+        anyOf: # Extensible enum. See https://opensource.zalando.com/restful-api-guidelines/#112
+          - type: string
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+)$
+            description: |-
+              Any valid [Concept ID](../index.md#concept-id).
+          - const: "ord:represents"
+            description: |-
+              The Schema is a full, physical representation (data contract) of the referenced Entity Type.
+          - const: "ord:partial-representation"
+            description: |-
+              The Schema represents only a subset (partial view) of the referenced Entity Type.
+        examples:
+          - "ord:represents"
+    required:
+      - ordId
+    additionalProperties: false
 
   ############################################################################################################
 
@@ -5624,6 +5947,62 @@ definitions:
         examples:
           - "sap.s4.sot:entityType:BusinessPartner:v1"
 
+    required:
+      - ordId
+    additionalProperties: false
+
+  ############################################################################################################
+
+  RelatedSchema:
+    title: Related Schema
+    x-introduced-in-version: "1.17.0"
+    x-feature-status: beta
+    x-ums-type: "embedded"
+    type: object
+    description: |-
+      Defines a relationship from a resource (e.g. an API Resource, Event Resource, or Capability) to a
+      [Schema](#schema) (via its ORD ID).
+
+      Use `relationType` to qualify the nature of the relationship, e.g. whether the Schema is exposed
+      (contained) by the resource or referenced as an event payload.
+    properties:
+      ordId:
+        <<: *ordId
+        pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):(schema):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$
+        x-association-target:
+          - "#/definitions/Schema/ordId"
+        x-ums-reverse-relationship:
+          propertyName: relatedFromResources
+          description: |-
+            The resources that declare a relationship to the given Schema.
+          min: 0
+          max: "*"
+        examples:
+          - "sap.foo:schema:BusinessPartner:v1"
+      relationType:
+        type: string
+        description: |-
+          Optional type of the relationship, which defines a stricter semantic of what the relationship implies.
+
+          If not provided, the relationship type has no specific semantics; the Schema is "related somehow"
+          to the resource.
+
+          MUST be a valid [Concept ID](../index.md#concept-id).
+        anyOf: # Extensible enum. See https://opensource.zalando.com/restful-api-guidelines/#112
+          - type: string
+            pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-\/]+)$
+            description: |-
+              Any valid [Concept ID](../index.md#concept-id).
+          - const: "ord:exposes"
+            description: |-
+              The resource exposes (contains) the referenced Schema, e.g. as a request/response structure.
+              An API contract typically exposes many Schemas.
+          - const: "ord:payload"
+            description: |-
+              The resource references the Schema as its payload, e.g. an Event resource referencing the
+              payload Schema of its events (often published in a schema registry).
+        examples:
+          - "ord:exposes"
     required:
       - ordId
     additionalProperties: false

--- a/src/generated/spec/v1/types/Document.ts
+++ b/src/generated/spec/v1/types/Document.ts
@@ -43,7 +43,8 @@ export interface OrdDocument {
     | "1.13"
     | "1.14"
     | "1.15"
-    | "1.16";
+    | "1.16"
+    | "1.17";
   /**
    * Optional description of the ORD document itself.
    * Please note that this information is NOT further processed or considered by an ORD aggregator.
@@ -125,6 +126,14 @@ export interface OrdDocument {
    * Array of all capabilities that are described in this ORD document.
    */
   capabilities?: Capability[];
+  /**
+   * Array of all Schemas that are described in this ORD document.
+   *
+   * A Schema describes the concrete structure of a data object (e.g. a DTO, an event payload,
+   * or an API request/response model), described with formats such as JSON Schema, CSN Interop,
+   * Avro, Protobuf, or XSD.
+   */
+  schemas?: Schema[];
   /**
    * Array of all data products that are described in this ORD document.
    */
@@ -741,6 +750,13 @@ export interface ApiResource {
    */
   exposedEntityTypes?: ExposedEntityType[];
   /**
+   * Optional list of related [Schemas](#schema).
+   *
+   * An API contract typically exposes (contains) many Schemas as its request/response or payload structures.
+   * Use the `relationType` (e.g. `ord:exposes`) to qualify the relationship.
+   */
+  relatedSchemas?: RelatedSchema[];
+  /**
    * Links with semantic meaning that are specific to API Resources.
    */
   apiResourceLinks?: ApiAndEventResourceLink[];
@@ -1241,6 +1257,30 @@ export interface ExposedEntityType {
   ordId: string;
 }
 /**
+ * Defines a relationship from a resource (e.g. an API Resource, Event Resource, or Capability) to a
+ * [Schema](#schema) (via its ORD ID).
+ *
+ * Use `relationType` to qualify the nature of the relationship, e.g. whether the Schema is exposed
+ * (contained) by the resource or referenced as an event payload.
+ */
+export interface RelatedSchema {
+  /**
+   * The ORD ID is a stable, globally unique ID for ORD resources or taxonomy.
+   *
+   * It MUST be a valid [ORD ID](../index.md#ord-id) of the appropriate ORD type.
+   */
+  ordId: string;
+  /**
+   * Optional type of the relationship, which defines a stricter semantic of what the relationship implies.
+   *
+   * If not provided, the relationship type has no specific semantics; the Schema is "related somehow"
+   * to the resource.
+   *
+   * MUST be a valid [Concept ID](../index.md#concept-id).
+   */
+  relationType?: (string | "ord:exposes" | "ord:payload") & string;
+}
+/**
  * Links with specific semantic meaning that are related to API or event resources.
  *
  * If a generic [Link](#link) can also be expressed via an API / Event Resource Link, the latter MUST be chosen.
@@ -1638,6 +1678,13 @@ export interface EventResource {
    * MUST be a valid reference to an [EntityType](#entity-type) ORD ID.
    */
   exposedEntityTypes?: ExposedEntityType[];
+  /**
+   * Optional list of related [Schemas](#schema).
+   *
+   * An Event resource typically references one payload Schema per event (often published in a schema registry).
+   * Use the `relationType` (e.g. `ord:payload`) to qualify the relationship.
+   */
+  relatedSchemas?: RelatedSchema[];
   /**
    * Links with semantic meaning that are specific to event resources.
    *
@@ -2398,6 +2445,13 @@ export interface Capability {
    */
   relatedCapabilities?: RelatedCapability[];
   /**
+   * Optional list of related [Schemas](#schema).
+   *
+   * An API contract typically exposes (contains) many Schemas as its request/response or payload structures.
+   * Use the `relationType` (e.g. `ord:exposes`) to qualify the relationship.
+   */
+  relatedSchemas?: RelatedSchema[];
+  /**
    * List of available machine-readable definitions, which describe the resource in detail.
    * See also [Resource Definitions](../index.md#resource-definitions) for more context.
    *
@@ -2472,6 +2526,331 @@ export interface CapabilityDefinition {
    * Type of the capability resource definition
    */
   type: (string | "sap.mdo:mdi-capability-definition:v1" | "custom") & string;
+  /**
+   * If the fixed `type` enum values need to be extended, an arbitrary `customType` can be provided.
+   *
+   * MUST be a valid [Specification ID](../index.md#specification-id).
+   *
+   * MUST only be provided if `type` is set to `custom`.
+   */
+  customType?: string;
+  /**
+   * The [Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml) of the definition serialization format.
+   * A consuming application can use this information to know which file format parser it needs to use.
+   * For example, for OpenAPI 3, it's valid to express the same definition in both YAML and JSON.
+   *
+   * If no Media Type is registered for the referenced file,
+   * `text/plain` MAY be used for arbitrary plain-text and `application/octet-stream` for arbitrary binary data.
+   *
+   */
+  mediaType: string;
+  /**
+   * [URL reference](https://tools.ietf.org/html/rfc3986#section-4.1) (URL or relative reference) to the resource definition file.
+   *
+   * It is RECOMMENDED to provide a relative URL.
+   * If relative, it is resolved against the ORD Document's root [`baseUrl`](#ord-document_baseurl) (the ORD provider base URL).
+   */
+  url: string;
+  /**
+   * List of supported access strategies for retrieving metadata from the ORD provider.
+   * An ORD Consumer/ORD Aggregator MAY choose any of the strategies.
+   *
+   * The access strategies only apply to the metadata access and not the actual API access.
+   * The actual access to the APIs for clients is described via Consumption Bundles.
+   *
+   * If this property is not provided, the definition URL will be available through the same access strategy as this ORD document.
+   * It is RECOMMENDED anyway that the attached metadata definitions are available with the same access strategies, to simplify the aggregator crawling process.
+   *
+   * @minItems 1
+   */
+  accessStrategies?: [MetadataDefinitionAccessStrategy, ...MetadataDefinitionAccessStrategy[]];
+  /**
+   * The visibility states who is allowed to "see" and access the resource definition, in case it differs from the resource visibility.
+   *
+   * If not given, the resource definition has the same visibility as the resource it describes.
+   * The visibility of a resource definition MUST be lower (more restrictive) than the visibility of the resource it describes.
+   * E.g. a public resource can have metadata definitions that are internal only. An internal resource can't declare to have a public metadata definition.
+   *
+   * This makes it also possible to provide both a public and an internal metadata description of the resource,
+   * in case that some metadata must only be made accessible to internal consumers.
+   */
+  visibility?: "public" | "internal" | "private";
+  /**
+   * Marks a resource definition as a *complementary* variant of the resource's default definition,
+   * for example an overlay, an AI-enriched variant, or an agent-security-permissions view.
+   * All entries in the definitions list, with or without `purpose`, MUST describe the same
+   * underlying resource; see the list property for the full modelling rules.
+   *
+   * Together with `type` (or `customType`) and `visibility`, `purpose` forms the uniqueness
+   * key for entries in the definitions list.
+   *
+   * MUST be a valid [Concept ID](../index.md#concept-id). The `ord:` namespace is reserved for
+   * values standardized by the ORD specification itself; custom values MUST use a vendor- or
+   * product-specific namespace prefix (e.g. `foo.bar:my-purpose`).
+   */
+  purpose?: (string | "ord:ai-enrichment" | "ord:agent-security-permissions") & string;
+}
+/**
+ * A Schema describes the concrete structure of a data object, e.g. a Data Transfer Object (DTO),
+ * an event payload, or an API request/response model.
+ * A Schema can be described with formats such as JSON Schema, CSN Interop, Avro, Protobuf, or XSD.
+ *
+ * Schemas can also describe the contract of whole documents or declarative configuration objects,
+ * e.g. Kubernetes Custom Resource Definitions (CRDs). The ORD specification itself is such an example:
+ * it publishes a JSON Schema that describes the structure of ORD Documents.
+ *
+ * Unlike an [Entity Type](#entity-type), which represents a conceptual domain model or a business term
+ * (a "noun"), a Schema describes the concrete serialization structure ("how the data is shaped on the wire").
+ * A Schema MAY reference the Entity Type(s) it realizes via `relatedEntityTypes`, providing traceability
+ * between the conceptual model and its physical representation.
+ *
+ * Schemas are lightweight to describe (similar to [Capabilities](#capability)) and are meant to be reusable:
+ * API resources typically expose (contain) many Schemas, while Event resources typically reference one payload
+ * Schema each, often published in a schema registry. A Schema MAY also stand on its own (e.g. a document
+ * contract), in which case it need not be exposed by any API or Event.
+ *
+ * Please note that this concept is in beta and MAY be changed or removed at the provider's discretion.
+ */
+export interface Schema {
+  /**
+   * The ORD ID is a stable, globally unique ID for ORD resources or taxonomy.
+   *
+   * It MUST be a valid [ORD ID](../index.md#ord-id) of the appropriate ORD type.
+   */
+  ordId: string;
+  /**
+   * The locally unique ID under which this resource can be looked up / resolved in the described system itself.
+   * Unlike the ORD ID it's not globally unique, but it may be useful to document the original ID / technical name.
+   *
+   * It MAY also be used as the `<resourceName>` fragment in the ORD ID, IF it can fulfill the charset and length limitations within the ORD ID.
+   * But since this is not always possible, no assumptions MUST be made about the local ID being the same as the `<resourceName>` fragment in the ORD ID.
+   */
+  localId?: string;
+  /**
+   * Correlation IDs can be used to create a reference to related data in other repositories (especially to the system of record).
+   *
+   * They express an "identity" / "equals" / "mappable" relationship to the target ID.
+   *
+   * If a "part of" relationship needs to be expressed, use the `partOfGroups` assignment instead.
+   *
+   * MUST be a valid [Correlation ID](../index.md#correlation-id).
+   */
+  correlationIds?: string[];
+  /**
+   * Human-readable title.
+   *
+   * MUST NOT exceed 255 chars.
+   * MUST NOT contain line breaks.
+   */
+  title: string;
+  /**
+   * Plain text short description.
+   *
+   * MUST NOT exceed 255 chars.
+   * MUST NOT contain line breaks.
+   */
+  shortDescription?: string;
+  /**
+   * Full description, notated in [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * The description SHOULD not be excessive in length and is not meant to provide full documentation.
+   * Detailed documentation SHOULD be attached as (typed) links.
+   */
+  description?: string;
+  /**
+   * Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.
+   * Intentionally separate from human-facing `description` so both can evolve independently.
+   * SHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * For guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources).
+   */
+  aiHint?: string;
+  /**
+   * Defines which Package the resource is part of.
+   *
+   * MUST be a valid reference to a [Package](#package) ORD ID.
+   *
+   * Every resource MUST be part of one package.
+   */
+  partOfPackage?: string;
+  /**
+   * Defines which groups the resource is assigned to.
+   *
+   * The property is optional, but if given the value MUST be an array of valid Group IDs.
+   *
+   * Groups are a lightweight custom taxonomy concept.
+   * They express a "part of" relationship to the chosen group concept.
+   * If an "identity / equals" relationship needs to be expressed, use the `correlationIds` instead.
+   *
+   * All resources that share the same group ID assignment are effectively grouped together.
+   *
+   * **Visibility:** Groups and Group Types may carry a `visibility`. Aggregators and consumers MUST NOT expose
+   * group assignments to audiences whose access level exceeds the referenced Group's (or Group Type's) visibility.
+   * See [Visibility of Groups and Group Types](../concepts/grouping-and-bundling#visibility-of-groups-and-group-types).
+   */
+  partOfGroups?: string[];
+  /**
+   * The complete [SemVer](https://semver.org/) version string.
+   *
+   * It MUST follow the [Semantic Versioning 2.0.0](https://semver.org/) standard.
+   * It SHOULD be changed if the ORD information or referenced resource definitions changed.
+   * It SHOULD express minor and patch changes that don't lead to incompatible changes.
+   *
+   * When the `version` major version changes, the [ORD ID](../index.md#ord-id) `<majorVersion>` fragment SHOULD be updated to be identical.
+   * In case that a resource definition file also contains a version number (e.g. [OpenAPI `info`.`version`](https://spec.openapis.org/oas/v3.1.1.html#info-object)), it MUST be equal with the resource `version` to avoid inconsistencies.
+   *
+   * If the resource has been extended by the user, the change MUST be indicated via `lastUpdate`.
+   * The `version` MUST not be bumped for changes in extensions.
+   *
+   * The general [Version and Lifecycle](../concepts/versioning-and-lifecycle.md) flow MUST be followed.
+   *
+   * Note: A change is only relevant for a version increment, if it affects the ORD resource or ORD taxonomy directly.
+   * For example: If a resource within a `Package` changes, but the Package itself did not, the Package version does not need to be incremented.
+   */
+  version: string;
+  /**
+   * Optional, but RECOMMENDED indicator when (date-time) the last change to the resource (including its definitions) happened.
+   *
+   * The date format MUST comply with [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).
+   *
+   * When retrieved from an ORD aggregator, `lastUpdate` will be reliable there and reflect either the provider based update time or the aggregator processing time.
+   * Therefore consumers MAY rely on it to detect changes to the metadata and the attached resource definition files.
+   *
+   * If the resource has attached definitions, either the `version` or `lastUpdate` property MUST be defined and updated to let the ORD aggregator know that they need to be fetched again.
+   *
+   * Together with `perspectives`, this property SHOULD be used to optimize the metadata crawling process of the ORD aggregators.
+   */
+  lastUpdate?: string;
+  /**
+   * Defines metadata access control - which categories of consumers are allowed to discover and access the resource and its metadata.
+   *
+   * This controls who can see that the resource exists and retrieve its metadata level information.
+   * It does NOT control runtime access to the resource itself - that is managed separately through authentication and authorization mechanisms.
+   *
+   * Use this to prevent exposing internal implementation details to inappropriate consumer audiences.
+   */
+  visibility: "public" | "internal" | "private";
+  /**
+   * Defines the maturity level and stability commitment for the resource's API contract (interface, behavior, data models).
+   *
+   * This indicates whether the resource may undergo backward-incompatible changes. It helps consumers understand the risk
+   * of depending on the resource and whether it's suitable for production use.
+   *
+   * Note: This is independent of `visibility` and does not imply availability guarantees or SLAs - it concerns only the API contract stability.
+   *
+   * See [Lifecycle](../concepts/versioning-and-lifecycle.md#lifecycle) and [Compatibility](../concepts/compatibility.md) for more details.
+   */
+  releaseStatus: "development" | "beta" | "active" | "deprecated" | "sunset";
+  /**
+   * Optional schema evolution / compatibility mode, describing how future versions of this Schema
+   * are allowed to change relative to prior versions.
+   *
+   * This mirrors the compatibility modes found in schema registries (e.g. Confluent, AWS Glue, CNCF xRegistry).
+   */
+  compatibility?: "none" | "backward" | "forward" | "full";
+  /**
+   * Optional list of [Entity Type](#entity-type) Resources that this Schema represents / serializes.
+   *
+   * A Schema is a concrete, physical data contract (representation) for an Entity Type.
+   * The same Entity Type MAY have several Schemas as representations, depending on the API,
+   * protocol, or serialization format that exposes it. Use `relationType` to further qualify
+   * the relationship where useful.
+   */
+  relatedEntityTypes?: SchemaEntityTypeRelation[];
+  /**
+   * List of available machine-readable definitions, which describe the resource in detail.
+   * See also [Resource Definitions](../index.md#resource-definitions) for more context.
+   *
+   * Every entry MUST describe the *same* underlying resource. Allowed variations are alternative
+   * representations (different formats) and complementary artifacts distinguished by `purpose`
+   * (e.g. overlays, AI-enriched variants, agent-security-permissions views).
+   * This list MUST NOT be used to bundle multiple distinct resources under a single ORD resource.
+   * Model those as separate ORD resources instead.
+   *
+   * The entry without a `purpose` value is the primary/default definition for its `(type, visibility)`;
+   * consumers that don't filter by `purpose` MUST fall back to it. There SHOULD be exactly one such
+   * default per `(type, visibility)` combination.
+   *
+   * The combination of `type` (or `customType` for `type: "custom"`), `purpose`, and `visibility` MUST
+   * be unique within the list.
+   *
+   * It is RECOMMENDED to provide the definitions as they enable machine-readable use cases.
+   * If the definitions are added or changed, the `version` MUST be incremented.
+   * An ORD aggregator MAY only (re)fetch the definitions again when the `version` was incremented.
+   */
+  definitions?: SchemaDefinition[];
+  /**
+   * Generic Links with arbitrary meaning and content.
+   */
+  links?: Link[];
+  /**
+   * List of free text style tags.
+   * No special characters are allowed except `-`, `_`, `.`, `/` and ` `.
+   *
+   * Tags that are assigned to a `Package` are inherited to all of the ORD resources it contains.
+   */
+  tags?: string[];
+  labels?: Labels;
+  documentationLabels?: DocumentationLabels;
+  /**
+   * Defines whether this ORD resource is **system-instance-aware**.
+   * This is the case when the referenced resource definitions are potentially different between **system instances**.
+   *
+   * If this behavior applies, `systemInstanceAware` MUST be set to true.
+   * An ORD aggregator MUST then fetch the referenced resource definitions for _each_ **system instance** individually.
+   *
+   * This concept is now **deprecated** in favor of the more explicit `perspective` attribute.
+   * All resources that are system-instance-aware should ideally be put into a dedicated ORD document with `perspective`: `system-instance`.
+   *
+   * For more details, see [perspectives concept page](../concepts/perspectives.md) or the [specification section](../index.md#perspectives).
+   */
+  systemInstanceAware?: boolean;
+}
+/**
+ * Defines the relation between a [Schema](#schema) and an [Entity Type](#entity-type) (via its ORD ID).
+ *
+ * A Schema is a concrete, physical representation (data contract) of an Entity Type.
+ */
+export interface SchemaEntityTypeRelation {
+  /**
+   * The ORD ID is a stable, globally unique ID for ORD resources or taxonomy.
+   *
+   * It MUST be a valid [ORD ID](../index.md#ord-id) of the appropriate ORD type.
+   */
+  ordId: string;
+  /**
+   * Optional type of the relationship, which defines a stricter semantic of what the relationship implies.
+   *
+   * If not provided, the relationship type has no specific semantics; the Schema is "a representation of"
+   * the referenced Entity Type.
+   *
+   * MUST be a valid [Concept ID](../index.md#concept-id).
+   */
+  relationType?: (string | "ord:represents" | "ord:partial-representation") & string;
+}
+/**
+ * Link and categorization of a machine-readable schema definition.
+ */
+export interface SchemaDefinition {
+  /**
+   * Type of the schema definition.
+   *
+   * This is an extensible enum. Global industry-standard schema formats are standardized by ORD as bare
+   * (unprefixed) values, consistent with existing resource definition types such as `openapi-v3` or
+   * `asyncapi-v2`. Formats that are specific to a vendor or organization use a namespace-prefixed
+   * [Specification ID](../index.md#specification-id) (e.g. `sap-csn-interop-effective-v1` for CSN Interop).
+   */
+  type: (
+    | string
+    | "json-schema-v7"
+    | "json-schema-v2020-12"
+    | "avro-v1"
+    | "protobuf-v3"
+    | "xsd-v1"
+    | "sap-csn-interop-effective-v1"
+    | "custom"
+  ) &
+    string;
   /**
    * If the fixed `type` enum values need to be extended, an arbitrary `customType` can be provided.
    *

--- a/static/spec-v1/interfaces/ums/AbstractTypeMapping/ordresource.yaml
+++ b/static/spec-v1/interfaces/ums/AbstractTypeMapping/ordresource.yaml
@@ -26,3 +26,6 @@ spec:
     - includedType:
         name: 'Capability'
         namespace: '/sap/core/ucl/metadata/ord/v1'
+    - includedType:
+        name: 'Schema'
+        namespace: '/sap/core/ucl/metadata/ord/v1'

--- a/static/spec-v1/interfaces/ums/MetadataType/apiresource.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/apiresource.yaml
@@ -436,6 +436,10 @@ spec:
       relatedTypeName: 'ExposedEntityType'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       description: "Optional list of [entity types](#entity-type) that are exposed by the resource.\n\nThis replaces `entityTypeMappings`. If both is given, the `exposedEntityTypes` wins.\n\nMUST be a valid reference to an [EntityType](#entity-type) ORD ID."
+    - propertyName: 'relatedSchemas'
+      relatedTypeName: 'RelatedSchema'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      description: "Optional list of related [Schemas](#schema).\n\nAn API contract typically exposes (contains) many Schemas as its request/response or payload structures.\nUse the `relationType` (e.g. `ord:exposes`) to qualify the relationship."
     - propertyName: 'extensible'
       relatedTypeName: 'Extensible'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'

--- a/static/spec-v1/interfaces/ums/MetadataType/capability.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/capability.yaml
@@ -249,6 +249,10 @@ spec:
       relatedTypeName: 'RelatedCapability'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       description: "Optional list of related Capabilities.\n\nUse this to indicate dependencies, extensions, or other relationships between capabilities."
+    - propertyName: 'relatedSchemas'
+      relatedTypeName: 'RelatedSchema'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      description: "Optional list of related [Schemas](#schema).\n\nAn API contract typically exposes (contains) many Schemas as its request/response or payload structures.\nUse the `relationType` (e.g. `ord:exposes`) to qualify the relationship."
     - propertyName: 'inverseRelatedCapabilities'
       relatedTypeName: 'RelatedCapability'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'

--- a/static/spec-v1/interfaces/ums/MetadataType/eventresource.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/eventresource.yaml
@@ -418,6 +418,10 @@ spec:
       relatedTypeName: 'ExposedEntityType'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       description: "Optional list of [entity types](#entity-type) that are exposed by the resource.\n\nThis replaces `entityTypeMappings`. If both is given, the `exposedEntityTypes` wins.\n\nMUST be a valid reference to an [EntityType](#entity-type) ORD ID."
+    - propertyName: 'relatedSchemas'
+      relatedTypeName: 'RelatedSchema'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      description: "Optional list of related [Schemas](#schema).\n\nAn Event resource typically references one payload Schema per event (often published in a schema registry).\nUse the `relationType` (e.g. `ord:payload`) to qualify the relationship."
     - propertyName: 'extensible'
       relatedTypeName: 'Extensible'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'

--- a/static/spec-v1/interfaces/ums/MetadataType/group.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/group.yaml
@@ -111,6 +111,11 @@ spec:
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       description: 'The Capabilities that are part the given Group.'
       mandatory: false
+    - propertyName: 'schemaMembers'
+      relatedTypeName: 'Schema'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      description: 'The Schemas that are part of the given Group.'
+      mandatory: false
     - propertyName: 'integrationDependencyMembers'
       relatedTypeName: 'IntegrationDependency'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'

--- a/static/spec-v1/interfaces/ums/MetadataType/package.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/package.yaml
@@ -249,6 +249,11 @@ spec:
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       description: 'The capabilities that are part the given Package.'
       mandatory: false
+    - propertyName: 'schemas'
+      relatedTypeName: 'Schema'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      description: 'The Schemas that are part of the given Package.'
+      mandatory: false
     - propertyName: 'integrationDependencies'
       relatedTypeName: 'IntegrationDependency'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'

--- a/static/spec-v1/interfaces/ums/MetadataType/relatedschema.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/relatedschema.yaml
@@ -1,0 +1,40 @@
+apiVersion: 'metadata-service.resource.api.sap/v6alpha1'
+type: 'MetadataType'
+metadata:
+  name: 'relatedschema'
+  path: '/sap/core/ucl/metadata/ord/v1'
+  labels: {}
+spec:
+  typeName: 'RelatedSchema'
+  key:
+    - 'id'
+  visibility: 'public'
+  embedded: true
+  description: "Defines a relationship from a resource (e.g. an API Resource, Event Resource, or Capability) to a\n[Schema](#schema) (via its ORD ID).\n\nUse `relationType` to qualify the nature of the relationship, e.g. whether the Schema is exposed\n(contained) by the resource or referenced as an event payload."
+  metadataProperties:
+    - name: 'id'
+      type: 'guid'
+      mandatory: true
+      unique: true
+      description: 'UMS ID (globally unique), used for relations.'
+    - name: 'ordId_ID'
+      type: 'guid'
+      description: "The ORD ID is a stable, globally unique ID for ORD resources or taxonomy.\n\nIt MUST be a valid [ORD ID](../index.md#ord-id) of the appropriate ORD type."
+      mandatory: true
+      constraints:
+        maxLength: 255
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(schema):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
+    - name: 'relationType'
+      type: 'string'
+      description: "Optional type of the relationship, which defines a stricter semantic of what the relationship implies.\n\nIf not provided, the relationship type has no specific semantics; the Schema is \"related somehow\"\nto the resource.\n\nMUST be a valid [Concept ID](../index.md#concept-id)."
+  customTypeDefinitions: []
+  metadataRelations:
+    - propertyName: 'ordId'
+      relatedTypeName: 'Schema'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      propertyBased: true
+      managedByProperty: 'ordId_ID'
+      description: "The ORD ID is a stable, globally unique ID for ORD resources or taxonomy.\n\nIt MUST be a valid [ORD ID](../index.md#ord-id) of the appropriate ORD type."
+      mandatory: true
+      reverseRelation:
+        relationPropertyName: 'relatedFromResources'

--- a/static/spec-v1/interfaces/ums/MetadataType/schema.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/schema.yaml
@@ -1,16 +1,16 @@
 apiVersion: 'metadata-service.resource.api.sap/v6alpha1'
 type: 'MetadataType'
 metadata:
-  name: 'entitytype'
+  name: 'schema'
   path: '/sap/core/ucl/metadata/ord/v1'
   labels: {}
 spec:
-  typeName: 'EntityType'
+  typeName: 'Schema'
   key:
     - 'id'
   visibility: 'public'
   embedded: false
-  description: "An [**Entity Type**](../concepts/grouping-and-bundling#entity-type) describes either a business concept / term or an underlying conceptual model (e.g. a business object / domain model).\nEntity Types can be related to API & Event resources, Data Products and other Entity Types, connecting exposed resources to business semantics.\n\nTo learn more about the concept, see [Entity Type](../concepts/grouping-and-bundling#entity-type)."
+  description: "A Schema describes the concrete structure of a data object, e.g. a Data Transfer Object (DTO),\nan event payload, or an API request/response model.\nA Schema can be described with formats such as JSON Schema, CSN Interop, Avro, Protobuf, or XSD.\n\nSchemas can also describe the contract of whole documents or declarative configuration objects,\ne.g. Kubernetes Custom Resource Definitions (CRDs). The ORD specification itself is such an example:\nit publishes a JSON Schema that describes the structure of ORD Documents.\n\nUnlike an [Entity Type](#entity-type), which represents a conceptual domain model or a business term\n(a \"noun\"), a Schema describes the concrete serialization structure (\"how the data is shaped on the wire\").\nA Schema MAY reference the Entity Type(s) it realizes via `relatedEntityTypes`, providing traceability\nbetween the conceptual model and its physical representation.\n\nSchemas are lightweight to describe (similar to [Capabilities](#capability)) and are meant to be reusable:\nAPI resources typically expose (contain) many Schemas, while Event resources typically reference one payload\nSchema each, often published in a schema registry. A Schema MAY also stand on its own (e.g. a document\ncontract), in which case it need not be exposed by any API or Event.\n\nPlease note that this concept is in beta and MAY be changed or removed at the provider's discretion."
   metadataProperties:
     - name: 'id'
       type: 'guid'
@@ -23,11 +23,10 @@ spec:
       mandatory: true
       constraints:
         maxLength: 255
-        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(entityType):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(schema):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
     - name: 'localId'
       type: 'string'
       description: "The locally unique ID under which this resource can be looked up / resolved in the described system itself.\nUnlike the ORD ID it's not globally unique, but it may be useful to document the original ID / technical name.\n\nIt MAY also be used as the `<resourceName>` fragment in the ORD ID, IF it can fulfill the charset and length limitations within the ORD ID.\nBut since this is not always possible, no assumptions MUST be made about the local ID being the same as the `<resourceName>` fragment in the ORD ID."
-      mandatory: true
       constraints:
         maxLength: 255
     - name: 'correlationIds'
@@ -60,7 +59,6 @@ spec:
     - name: 'partOfPackage_ID'
       type: 'guid'
       description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
-      mandatory: true
       constraints:
         maxLength: 255
         pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(package):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
@@ -68,10 +66,6 @@ spec:
       type: 'guid'
       array: true
       description: "Defines which groups the resource is assigned to.\n\nThe property is optional, but if given the value MUST be an array of valid Group IDs.\n\nGroups are a lightweight custom taxonomy concept.\nThey express a \"part of\" relationship to the chosen group concept.\nIf an \"identity / equals\" relationship needs to be expressed, use the `correlationIds` instead.\n\nAll resources that share the same group ID assignment are effectively grouped together.\n\n**Visibility:** Groups and Group Types may carry a `visibility`. Aggregators and consumers MUST NOT expose\ngroup assignments to audiences whose access level exceeds the referenced Group's (or Group Type's) visibility.\nSee [Visibility of Groups and Group Types](../concepts/grouping-and-bundling#visibility-of-groups-and-group-types)."
-    - name: 'partOfProducts_ID'
-      type: 'guid'
-      array: true
-      description: "List of products this package and its resources are a part of.\n\nMUST be a valid reference to a [Product](#product) ORD ID.\n\n`partOfProducts` assigned to a `Package` are inherited by all ORD resources it contains.\nResources that belong to a different product than their package can override this directly.\n\nEvery ORD resource SHOULD be assigned to at least one product, either directly or inherited from its package.\nSetting `partOfProducts` on the package is the preferred approach, as it propagates automatically to all contained resources."
     - name: 'version'
       type: 'string'
       description: "The complete [SemVer](https://semver.org/) version string.\n\nIt MUST follow the [Semantic Versioning 2.0.0](https://semver.org/) standard.\nIt SHOULD be changed if the ORD information or referenced resource definitions changed.\nIt SHOULD express minor and patch changes that don't lead to incompatible changes.\n\nWhen the `version` major version changes, the [ORD ID](../index.md#ord-id) `<majorVersion>` fragment SHOULD be updated to be identical.\nIn case that a resource definition file also contains a version number (e.g. [OpenAPI `info`.`version`](https://spec.openapis.org/oas/v3.1.1.html#info-object)), it MUST be equal with the resource `version` to avoid inconsistencies.\n\nIf the resource has been extended by the user, the change MUST be indicated via `lastUpdate`.\nThe `version` MUST not be bumped for changes in extensions.\n\nThe general [Version and Lifecycle](../concepts/versioning-and-lifecycle.md) flow MUST be followed.\n\nNote: A change is only relevant for a version increment, if it affects the ORD resource or ORD taxonomy directly.\nFor example: If a resource within a `Package` changes, but the Package itself did not, the Package version does not need to be incremented."
@@ -89,30 +83,14 @@ spec:
       type: 'string'
       description: "Defines the maturity level and stability commitment for the resource's API contract (interface, behavior, data models).\n\nThis indicates whether the resource may undergo backward-incompatible changes. It helps consumers understand the risk\nof depending on the resource and whether it's suitable for production use.\n\nNote: This is independent of `visibility` and does not imply availability guarantees or SLAs - it concerns only the API contract stability.\n\nSee [Lifecycle](../concepts/versioning-and-lifecycle.md#lifecycle) and [Compatibility](../concepts/compatibility.md) for more details."
       mandatory: true
-    - name: 'deprecationDate'
+    - name: 'compatibility'
       type: 'string'
-      description: "The deprecation date defines when the resource has been set as deprecated.\nThis is not to be confused with the `sunsetDate` which defines when the resource will be actually sunset, aka. decommissioned / removed / archived.\n\nThe date format MUST comply with [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6)."
-    - name: 'sunsetDate'
-      type: 'string'
-      description: "The sunset date defines when the resource is scheduled to be decommissioned / removed / archived.\n\nIf the `releaseStatus` is set to `deprecated`, the `sunsetDate` SHOULD be provided (if already known).\nOnce the sunset date is known and ready to be communicated externally, it MUST be provided here.\n\nThe date format MUST comply with [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6)."
-    - name: 'successors_ID'
-      type: 'guid'
-      array: true
-      description: "The successor resource(s).\n\nMUST be a valid reference to an ORD ID.\n\nIf the `releaseStatus` is set to `deprecated`, `successors` MUST be provided if one exists.\nIf `successors` is given, the described resource SHOULD set its `releaseStatus` to `deprecated`."
-    - name: 'changelogEntries'
-      type: 'custom'
-      customTypeName: 'ChangelogEntry'
-      array: true
-      description: 'Contains changelog entries that summarize changes with special regards to version and releaseStatus'
-    - name: 'level'
-      type: 'string'
-      description: "Defining the abstraction level of the entity type using the DDD terminology.\n\nIn Domain-Driven Design, there is a concept of domain entities and aggregates.\nThere are root entities which may contain further sub entities by composition.\nThe complete \"package\" is then called an aggregate, which gets its name and identity from the root entity.\nAn aggregate is a cluster of domain objects that can be treated as a single unit.\nThe root is the entity that is referenced from outside the aggregate. There must be only one root per aggregate.\nThe root ensures the integrity of the aggregate. A sub entity is any other non-root entity in the aggregate.\n\nSource, see [Martin Fowler on DDD Aggregate](https://martinfowler.com/bliki/DDD_Aggregate.html)"
-      mandatory: true
+      description: "Optional schema evolution / compatibility mode, describing how future versions of this Schema\nare allowed to change relative to prior versions.\n\nThis mirrors the compatibility modes found in schema registries (e.g. Confluent, AWS Glue, CNCF xRegistry)."
     - name: 'definitions'
       type: 'custom'
-      customTypeName: 'EntityTypeDefinition'
+      customTypeName: 'SchemaDefinition'
       array: true
-      description: 'List of available machine-readable definitions that describe the entity type''s internal model in detail.'
+      description: "List of available machine-readable definitions, which describe the resource in detail.\nSee also [Resource Definitions](../index.md#resource-definitions) for more context.\n\nEvery entry MUST describe the *same* underlying resource. Allowed variations are alternative\nrepresentations (different formats) and complementary artifacts distinguished by `purpose`\n(e.g. overlays, AI-enriched variants, agent-security-permissions views).\nThis list MUST NOT be used to bundle multiple distinct resources under a single ORD resource.\nModel those as separate ORD resources instead.\n\nThe entry without a `purpose` value is the primary/default definition for its `(type, visibility)`;\nconsumers that don't filter by `purpose` MUST fall back to it. There SHOULD be exactly one such\ndefault per `(type, visibility)` combination.\n\nThe combination of `type` (or `customType` for `type: \"custom\"`), `purpose`, and `visibility` MUST\nbe unique within the list.\n\nIt is RECOMMENDED to provide the definitions as they enable machine-readable use cases.\nIf the definitions are added or changed, the `version` MUST be incremented.\nAn ORD aggregator MAY only (re)fetch the definitions again when the `version` was incremented."
     - name: 'links'
       type: 'custom'
       customTypeName: 'Link'
@@ -130,62 +108,31 @@ spec:
       type: 'custom'
       customTypeName: 'DocumentationLabels'
       description: 'Generic documentation labels that can be applied to most ORD information.'
-    - name: 'policyLevel'
-      type: 'string'
-      description: "The [policy level](../../spec-extensions/policy-levels/) (aka. compliance level) that the described resources need to be compliant with.\nDepending on the chosen policy level, additional expectations and validations rules will be applied.\n\nThe policy level can be defined on ORD Document level, but also be overwritten on an individual package or resource level.\n"
-    - name: 'customPolicyLevel'
-      type: 'string'
-      description: "If the fixed `policyLevel` values need to be extended, an arbitrary `customPolicyLevel` can be provided.\nThe policy level is inherited from packages to resources they contain, but can be overwritten at resource level.\n\nMUST only be provided if `policyLevel` is set to `custom`.\nMUST be a valid [Specification ID](../index.md#specification-id)."
-      constraints:
-        maxLength: 255
-        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
-    - name: 'policyLevels'
-      type: 'string'
-      array: true
-      description: "A list of [policy levels](../../spec-extensions/policy-levels/) that the described resources need to be compliant with.\nFor each chosen policy level, additional expectations and validations rules will be applied.\n\nPolicy levels can be defined on ORD Document level, but also be overwritten on an individual package or resource level.\n\nA policy level MUST be a valid [Specification ID](../index.md#specification-id)."
     - name: 'systemInstanceAware'
       type: 'boolean'
       description: "Defines whether this ORD resource is **system-instance-aware**.\nThis is the case when the referenced resource definitions are potentially different between **system instances**.\n\nIf this behavior applies, `systemInstanceAware` MUST be set to true.\nAn ORD aggregator MUST then fetch the referenced resource definitions for _each_ **system instance** individually.\n\nThis concept is now **deprecated** in favor of the more explicit `perspective` attribute.\nAll resources that are system-instance-aware should ideally be put into a dedicated ORD document with `perspective`: `system-instance`.\n\nFor more details, see [perspectives concept page](../concepts/perspectives.md) or the [specification section](../index.md#perspectives)."
   customTypeDefinitions:
-    - name: 'ChangelogEntry'
-      metadataProperties:
-        - name: 'version'
-          type: 'string'
-          description: "Full version number that corresponds to the `version` that is described by the changelog entry.\n\nIdeally it follows the [Semantic Versioning 2.0.0](https://semver.org/) standard,\nbut since it should reflect the actual version string / scheme used, this is not a mandatory requirement."
-          mandatory: true
-          constraints:
-            minLength: 1
-        - name: 'releaseStatus'
-          type: 'string'
-          description: "Defines the maturity level and stability commitment for the resource's API contract (interface, behavior, data models).\n\nThis indicates whether the resource may undergo backward-incompatible changes. It helps consumers understand the risk\nof depending on the resource and whether it's suitable for production use.\n\nNote: This is independent of `visibility` and does not imply availability guarantees or SLAs - it concerns only the API contract stability.\n\nSee [Lifecycle](../concepts/versioning-and-lifecycle.md#lifecycle) and [Compatibility](../concepts/compatibility.md) for more details."
-          mandatory: true
-        - name: 'date'
-          type: 'date'
-          description: "Date of change, without time or timezone information.\n\nThe date format MUST comply with [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6)."
-          mandatory: true
-        - name: 'description'
-          type: 'string'
-          description: "Full description, notated in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nThe description SHOULD not be excessive in length and is not meant to provide full documentation.\nDetailed documentation SHOULD be attached as (typed) links."
-          constraints:
-            minLength: 1
-        - name: 'url'
-          type: 'string'
-          description: "Optional [URL](https://tools.ietf.org/html/rfc3986) that links to a more detailed changelog entry.\n\nThe link target MUST be absolute and SHOULD be openly accessible."
-    - name: 'EntityTypeDefinition'
+    - name: 'SchemaDefinition'
       metadataProperties:
         - name: 'type'
           type: 'string'
-          description: "Type of the entity type resource definition.\n\nMUST be either:\n- any valid [Specification ID](../index.md#specification-id), or\n- one of the pre-defined values listed below."
+          description: "Type of the schema definition.\n\nThis is an extensible enum. Global industry-standard schema formats are standardized by ORD as bare\n(unprefixed) values, consistent with existing resource definition types such as `openapi-v3` or\n`asyncapi-v2`. Formats that are specific to a vendor or organization use a namespace-prefixed\n[Specification ID](../index.md#specification-id) (e.g. `sap-csn-interop-effective-v1` for CSN Interop)."
           mandatory: true
+        - name: 'customType'
+          type: 'string'
+          description: "If the fixed `type` enum values need to be extended, an arbitrary `customType` can be provided.\n\nMUST be a valid [Specification ID](../index.md#specification-id).\n\nMUST only be provided if `type` is set to `custom`."
+          constraints:
+            maxLength: 255
+            pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
         - name: 'mediaType'
           type: 'string'
-          description: "[Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml) that describes the format of the definition.\n\nMedia Types under `application/*` and `text/*` are allowed.\nIf no Media Type is registered for the referenced file,\n`text/plain` MAY be used for arbitrary plain-text and `application/octet-stream` for arbitrary binary data."
+          description: "The [Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml) of the definition serialization format.\nA consuming application can use this information to know which file format parser it needs to use.\nFor example, for OpenAPI 3, it's valid to express the same definition in both YAML and JSON.\n\nIf no Media Type is registered for the referenced file,\n`text/plain` MAY be used for arbitrary plain-text and `application/octet-stream` for arbitrary binary data.\n"
           mandatory: true
           constraints:
             pattern: '^(application|text)\/[a-zA-Z0-9][a-zA-Z0-9.+\-]*$'
         - name: 'url'
           type: 'string'
-          description: "[URL reference](https://tools.ietf.org/html/rfc3986#section-4.1) (URL or relative reference) to the resource definition file.\n\nIt is RECOMMENDED to provide a relative URL (to base URL)."
+          description: "[URL reference](https://tools.ietf.org/html/rfc3986#section-4.1) (URL or relative reference) to the resource definition file.\n\nIt is RECOMMENDED to provide a relative URL.\nIf relative, it is resolved against the ORD Document's root [`baseUrl`](#ord-document_baseurl) (the ORD provider base URL)."
           mandatory: true
         - name: 'accessStrategies'
           type: 'custom'
@@ -194,8 +141,10 @@ spec:
           description: "List of supported access strategies for retrieving metadata from the ORD provider.\nAn ORD Consumer/ORD Aggregator MAY choose any of the strategies.\n\nThe access strategies only apply to the metadata access and not the actual API access.\nThe actual access to the APIs for clients is described via Consumption Bundles.\n\nIf this property is not provided, the definition URL will be available through the same access strategy as this ORD document.\nIt is RECOMMENDED anyway that the attached metadata definitions are available with the same access strategies, to simplify the aggregator crawling process."
         - name: 'visibility'
           type: 'string'
-          description: "Who is allowed to access the entity type definition. Defaults to `private`.\n\nEntity Type definitions are internal implementation details and SHOULD remain `private` by default.\nConsumers interact with the data through related API Resources, not the internal model directly.\n\nThe visibility MUST be equal to or more restrictive than the Entity Type resource's visibility.\n\nOnly use `public` visibility when the internal model definition itself needs open access for standardization or documentation purposes."
-          mandatory: true
+          description: "The visibility states who is allowed to \"see\" and access the resource definition, in case it differs from the resource visibility.\n\nIf not given, the resource definition has the same visibility as the resource it describes.\nThe visibility of a resource definition MUST be lower (more restrictive) than the visibility of the resource it describes.\nE.g. a public resource can have metadata definitions that are internal only. An internal resource can't declare to have a public metadata definition.\n\nThis makes it also possible to provide both a public and an internal metadata description of the resource,\nin case that some metadata must only be made accessible to internal consumers."
+        - name: 'purpose'
+          type: 'string'
+          description: "Marks a resource definition as a *complementary* variant of the resource's default definition,\nfor example an overlay, an AI-enriched variant, or an agent-security-permissions view.\nAll entries in the definitions list, with or without `purpose`, MUST describe the same\nunderlying resource; see the list property for the full modelling rules.\n\nTogether with `type` (or `customType`) and `visibility`, `purpose` forms the uniqueness\nkey for entries in the definitions list.\n\nMUST be a valid [Concept ID](../index.md#concept-id). The `ord:` namespace is reserved for\nvalues standardized by the ORD specification itself; custom values MUST use a vendor- or\nproduct-specific namespace prefix (e.g. `foo.bar:my-purpose`)."
     - name: 'AccessStrategy'
       metadataProperties:
         - name: 'type'
@@ -249,9 +198,8 @@ spec:
       propertyBased: true
       managedByProperty: 'partOfPackage_ID'
       description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
-      mandatory: true
       reverseRelation:
-        relationPropertyName: 'entityTypes'
+        relationPropertyName: 'schemas'
     - propertyName: 'partOfGroups'
       relatedTypeName: 'Group'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
@@ -259,49 +207,13 @@ spec:
       managedByProperty: 'partOfGroups_ID'
       description: "Defines which groups the resource is assigned to.\n\nThe property is optional, but if given the value MUST be an array of valid Group IDs.\n\nGroups are a lightweight custom taxonomy concept.\nThey express a \"part of\" relationship to the chosen group concept.\nIf an \"identity / equals\" relationship needs to be expressed, use the `correlationIds` instead.\n\nAll resources that share the same group ID assignment are effectively grouped together.\n\n**Visibility:** Groups and Group Types may carry a `visibility`. Aggregators and consumers MUST NOT expose\ngroup assignments to audiences whose access level exceeds the referenced Group's (or Group Type's) visibility.\nSee [Visibility of Groups and Group Types](../concepts/grouping-and-bundling#visibility-of-groups-and-group-types)."
       reverseRelation:
-        relationPropertyName: 'entityTypeMembers'
-    - propertyName: 'partOfProducts'
-      relatedTypeName: 'Product'
-      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
-      propertyBased: true
-      managedByProperty: 'partOfProducts_ID'
-      description: "List of products this package and its resources are a part of.\n\nMUST be a valid reference to a [Product](#product) ORD ID.\n\n`partOfProducts` assigned to a `Package` are inherited by all ORD resources it contains.\nResources that belong to a different product than their package can override this directly.\n\nEvery ORD resource SHOULD be assigned to at least one product, either directly or inherited from its package.\nSetting `partOfProducts` on the package is the preferred approach, as it propagates automatically to all contained resources."
-    - propertyName: 'successors'
-      relatedTypeName: 'EntityType'
-      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
-      propertyBased: true
-      managedByProperty: 'successors_ID'
-      description: "The successor resource(s).\n\nMUST be a valid reference to an ORD ID.\n\nIf the `releaseStatus` is set to `deprecated`, `successors` MUST be provided if one exists.\nIf `successors` is given, the described resource SHOULD set its `releaseStatus` to `deprecated`."
+        relationPropertyName: 'schemaMembers'
     - propertyName: 'relatedEntityTypes'
-      relatedTypeName: 'RelatedEntityType'
-      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
-      description: "States that this Entity Type is related to another Entity Type.\n\nUsually this happens if there are similar conceptual entity types across different namespaces."
-    - propertyName: 'extensible'
-      relatedTypeName: 'Extensible'
-      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
-      description: "Describes extensibility (by customers or partners) of this resource.\nExtensibility usually happens at run-time by the end-users.\nExtensions can be field or entity extensions that come on top of the baseline contract.\n\nChanges in extensions do not lead to an increase in the `version`, but MUST lead to an updated `lastUpdate` date.\n\nSince the extensions are managed by the customer or a partner, whether those changes are compatible or not is not guaranteed by the base contract of the resource."
-    - propertyName: 'dataProducts'
-      relatedTypeName: 'DataProduct'
-      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
-      description: 'Data Products associated to the Entity Type.'
-      mandatory: false
-    - propertyName: 'agents'
-      relatedTypeName: 'Agent'
-      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
-      description: 'Agents associated to the Entity Type.'
-      mandatory: false
-    - propertyName: 'capabilities'
-      relatedTypeName: 'Capability'
-      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
-      description: 'Capabilities associated to the Entity Type.'
-      mandatory: false
-    - propertyName: 'schemas'
       relatedTypeName: 'SchemaEntityTypeRelation'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
-      description: 'Schemas that materialize / serialize the given Entity Type.'
-      mandatory: false
-    - propertyName: 'inverseRelatedEntityTypes'
-      relatedTypeName: 'RelatedEntityType'
+      description: "Optional list of [Entity Type](#entity-type) Resources that this Schema represents / serializes.\n\nA Schema is a concrete, physical data contract (representation) for an Entity Type.\nThe same Entity Type MAY have several Schemas as representations, depending on the API,\nprotocol, or serialization format that exposes it. Use `relationType` to further qualify\nthe relationship where useful."
+    - propertyName: 'relatedFromResources'
+      relatedTypeName: 'RelatedSchema'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
-      description: 'Entity types that defined a relationship to this entity type'
+      description: 'The resources that declare a relationship to the given Schema.'
       mandatory: false

--- a/static/spec-v1/interfaces/ums/MetadataType/schemaentitytyperelation.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/schemaentitytyperelation.yaml
@@ -1,0 +1,40 @@
+apiVersion: 'metadata-service.resource.api.sap/v6alpha1'
+type: 'MetadataType'
+metadata:
+  name: 'schemaentitytyperelation'
+  path: '/sap/core/ucl/metadata/ord/v1'
+  labels: {}
+spec:
+  typeName: 'SchemaEntityTypeRelation'
+  key:
+    - 'id'
+  visibility: 'public'
+  embedded: true
+  description: "Defines the relation between a [Schema](#schema) and an [Entity Type](#entity-type) (via its ORD ID).\n\nA Schema is a concrete, physical representation (data contract) of an Entity Type."
+  metadataProperties:
+    - name: 'id'
+      type: 'guid'
+      mandatory: true
+      unique: true
+      description: 'UMS ID (globally unique), used for relations.'
+    - name: 'ordId_ID'
+      type: 'guid'
+      description: "The ORD ID is a stable, globally unique ID for ORD resources or taxonomy.\n\nIt MUST be a valid [ORD ID](../index.md#ord-id) of the appropriate ORD type."
+      mandatory: true
+      constraints:
+        maxLength: 255
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(entityType):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$'
+    - name: 'relationType'
+      type: 'string'
+      description: "Optional type of the relationship, which defines a stricter semantic of what the relationship implies.\n\nIf not provided, the relationship type has no specific semantics; the Schema is \"a representation of\"\nthe referenced Entity Type.\n\nMUST be a valid [Concept ID](../index.md#concept-id)."
+  customTypeDefinitions: []
+  metadataRelations:
+    - propertyName: 'ordId'
+      relatedTypeName: 'EntityType'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      propertyBased: true
+      managedByProperty: 'ordId_ID'
+      description: "The ORD ID is a stable, globally unique ID for ORD resources or taxonomy.\n\nIt MUST be a valid [ORD ID](../index.md#ord-id) of the appropriate ORD type."
+      mandatory: true
+      reverseRelation:
+        relationPropertyName: 'schemas'


### PR DESCRIPTION
## Summary

Introduces **Schema** as a new, lightweight top-level ORD concept (beta).

A **Schema** describes the concrete structure of a data object: a DTO, an event payload, an API request/response model, or the contract of a whole document / declarative-config object (e.g. a Kubernetes CRD — ORD's own published JSON Schema for ORD Documents is such an example).

This is deliberately **distinct from `EntityType`**:

| | EntityType | Schema |
|---|---|---|
| Represents | conceptual domain model / business term (a "noun") | concrete serialization structure ("how it is shaped on the wire") |
| Answers | *what it means* | *how it is shaped* |

The same EntityType can have several Schemas as physical representations, depending on API/protocol/format. A Schema references the EntityType(s) it represents (direction: **Schema → EntityType**) via `relatedEntityTypes` as `{ordId, relationType}` objects (`ord:represents` / `ord:partial-representation`, extensible).

## Design decisions

- **Modeled on `Capability`** (lean). Required: `ordId`, `title`, `version`, `releaseStatus`, `visibility`. `partOfPackage` is **optional** (lighter than Capability).
- Optional **`compatibility`** mode (`none`/`backward`/`forward`/`full`), mirroring schema-registry semantics (Confluent, AWS Glue, CNCF xRegistry).
- **`SchemaDefinition`** mirrors `CapabilityDefinition` (`type`/`mediaType`/`url`/`accessStrategies`/`visibility`/`purpose`). `type` is an **extensible enum**: global industry-standard formats are bare consts (`json-schema-v7`, `json-schema-v2020-12`, `avro-v1`, `protobuf-v3`, `xsd-v1`, `sap-csn-interop-effective-v1`), consistent with existing `openapi-v3`/`asyncapi-v2`; anything else uses a namespace-prefixed Specification ID or `custom`.
- **`relatedSchemas` (not `exposedSchemas`) — resolved design decision.** The first draft used an `exposedSchemas` object on API/Event (mirroring `exposedEntityTypes`). We chose instead a single, uniform **`relatedSchemas`** field on `ApiResource`, `EventResource`, **and** `Capability`, modeled as a `RelatedSchema` object `{ordId, relationType}`. Rationale:
  - **Uniformity** — one field name and shape across all three resources, rather than `exposedSchemas` on some and `relatedSchemas` on others.
  - **Flexibility** — covers exposes/contains *and* looser associations without baking containment into the field name.
  - **Protocol/representation nuance lives in `relationType`** (extensible Concept ID), matching how the same EntityType can have different schemas per API/protocol. Seeded values: `ord:exposes` (schema contained in an API contract) and `ord:payload` (event payload schema).

## Relationships

- **API/Event/Capability → Schema:** `relatedSchemas` (`RelatedSchema` = `{ordId, relationType}`). An API contract typically relates many schemas (`ord:exposes`); an event references its payload schema (`ord:payload`).
- **Schema → EntityType:** `relatedSchemas`' counterpart on the Schema side is `relatedEntityTypes` (`SchemaEntityTypeRelation`), pointing to the concept it represents.

## Changes

- New definitions: `Schema`, `SchemaDefinition`, `SchemaEntityTypeRelation`, `RelatedSchema`.
- `schemas[]` array on the Document root (beta); added to `x-property-order`.
- `relatedSchemas` on `ApiResource`, `EventResource`, and `Capability` (beta).
- Added `"1.17"` to the `openResourceDiscovery` version enum.
- New concept doc page (`docs/spec-v1/concepts/schema.md`), a validating example (`examples/documents/document-schemas.json`), and a `CHANGELOG` entry.
- Regenerated types/interfaces/UMS metadata.

Introduced as **beta** so the enum values and relationships can iterate before locking.

## Open questions / for discussion

1. Naming: `Schema` vs `DataSchema` (potential confusion with "JSON Schema").
2. Should `compatibility` include transitive variants (`backward-transitive`, etc.)?
3. Schema-to-Schema composition references (Confluent-style) — needed now, or defer?
4. **`SchemaDefinition.type` seed set — which formats do we standardize now?** Do we keep `protobuf-v3`, and what else belongs in the initial list? The big three across every major registry (Confluent, AWS Glue, Apicurio) are **Avro, JSON Schema, and Protobuf** — Protobuf is a first-class citizen everywhere, so `protobuf-v3` looks warranted. Apicurio additionally handles OpenAPI, AsyncAPI, GraphQL, WSDL, and XSD. Since `type` is an extensible enum (anything can be added later via a namespaced Specification ID or `custom`), the question is which to *seed* as standardized bare consts vs leave to extension. Current seed: `json-schema-v7`, `json-schema-v2020-12`, `avro-v1`, `protobuf-v3`, `xsd-v1`, `sap-csn-interop-effective-v1`. Candidates to consider: newer JSON Schema drafts, `graphql-sdl` (already exists for API definitions). Also: is per-version granularity (`protobuf-v3` vs a single `protobuf`) the right approach?
5. Exact seed set of `relationType` values (`ord:exposes`, `ord:payload`, `ord:represents`, `ord:partial-representation`).
6. Guidance on Schema vs EntityType `definitions` (beta) so the same schema isn't described in both places.

## Verification

`npm run lint`, `npm run test` (16/16), and `npm run build` all pass. No broken links originate from the new pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
