### PR TITLE
feat(spec): add vendor and product assignments to ORD resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ### Changed
 
+- Added `vendor` directly to all ORD resources as an optional property.
+  When a contained resource omits it, ORD Aggregators SHOULD inherit the `vendor` assigned to its Package.
 - Clarified `OverlaySelectorByOperation` for OData targets: when the operation name alone is ambiguous (e.g. bound operations overloaded on multiple entity types), the selector MUST use the fully qualified signature (including parameters, e.g. `OData.Demo.Approval(Edm.Int32,Edm.String)`) or fall back to `jsonPath` to target the specific overload. When the name is already unique, the plain name remains sufficient. This makes explicit the pre-existing requirement that operation selectors resolve unambiguously.
 - Updated the ORD Overlay Tooling section to link the published reference implementation (`overlay-tools`), a set of React components for viewing Overlay documents (`overlay-editor`), and a reusable Go library (`overlay-golang`).
 

--- a/docs/spec-v1/index.md
+++ b/docs/spec-v1/index.md
@@ -611,8 +611,11 @@ The following rules need to be implemented by ORD aggregators:
   - Ideally this situation doesn't happen and the ORD Providers update `lastUpdate`. Then the date can also better reflect the time when the change happened, not when it was detected.
 - The aggregator MUST apply all defined inheritances from root document properties to all the ORD information that it contains.
   - `policyLevels` MUST be inherited to the resource / Package level, with the latter taking precedence.
-- The aggregator MUST apply all defined inheritances from `Package` properties to all the ORD resources that it contains.
-  - `vendor`, `partOfProducts`, `tags`, `countries`, `industry`, and `lineOfBusiness` MUST be merged without duplicates.
+- The following inheritance rules from `Package` properties apply to all the ORD resources that the Package contains.
+  - If a resource does not declare `vendor` directly, the aggregator SHOULD inherit the Package `vendor` onto the resource.
+    If both are present, the resource-level `vendor` SHOULD match the Package `vendor`.
+    If they differ, the explicitly assigned resource value takes precedence during aggregation.
+  - `partOfProducts`, `tags`, `countries`, `industry`, and `lineOfBusiness` MUST be merged without duplicates.
   - `labels` MUST be merged without duplicated values.
     - Values of the same label key will be merged.
     - Duplicate values of the same label key will be removed.

--- a/spec/v1/Document.schema.yaml
+++ b/spec/v1/Document.schema.yaml
@@ -548,6 +548,13 @@ definitions:
           MUST be set to `customer:vendor:Customer:` if the contents of the Package are created by the customer / user.
 
           MUST be set to a registered partner vendor, if the contents of the Package are created by a partner / third party.
+
+          An ORD Aggregator SHOULD inherit `vendor` to every ORD resource contained in the Package
+          when the resource does not declare `vendor` directly.
+          If both are present, the resource-level `vendor` SHOULD match the Package `vendor`.
+          If they differ, the explicitly assigned resource value takes precedence during aggregation.
+
+          The Package assignment remains the shared source for inheritance to contained resources.
         pattern: ^([a-z0-9]+(?:[.][a-z0-9]+)*):(vendor):([a-zA-Z0-9._\-]+):()$
         maxLength: 256
         x-association-target:
@@ -997,6 +1004,18 @@ definitions:
           - "Use this API to **retrieve** and **manage** dispute cases. Prefer structured JSON payloads over free-text fields when invoking tools."
 
       ## Assignments to bundling concepts
+
+      vendor:
+        <<: *vendor
+        description: &resourceVendorDescription |-
+          Vendor / organization that is the creator (or responsible party) of this resource.
+
+          MUST be a valid reference to a [Vendor](#vendor) ORD ID.
+
+          When omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)
+          referenced via `partOfPackage`.
+          If both are present, the resource-level `vendor` SHOULD match the Package `vendor`.
+          If they differ, the explicitly assigned resource value takes precedence during aggregation.
 
       partOfPackage: &partOfPackage
         type: string
@@ -1758,6 +1777,10 @@ definitions:
 
       ## Assignments to groupings
 
+      vendor:
+        <<: *vendor
+        description: *resourceVendorDescription
+
       partOfPackage:
         <<: *partOfPackage
         x-ums-reverse-relationship:
@@ -2052,6 +2075,10 @@ definitions:
       aiHint:
         <<: *aiHint
         examples: []
+
+      vendor:
+        <<: *vendor
+        description: *resourceVendorDescription
 
       partOfPackage:
         <<: *partOfPackage
@@ -2378,6 +2405,10 @@ definitions:
           - "Use this data product to access **customer order** data. Filter by `customerId` and `orderDate` for targeted queries. Output port `customerOrderItems` provides line-item detail."
 
       ## Assignment to Bundles
+
+      vendor:
+        <<: *vendor
+        description: *resourceVendorDescription
 
       partOfPackage:
         <<: *partOfPackage
@@ -3087,6 +3118,10 @@ definitions:
         examples:
           - "Invoke this agent to **resolve** open dispute cases. Provide the `caseId`; the agent autonomously gathers evidence, proposes resolution, and awaits approval before closing."
 
+      vendor:
+        <<: *vendor
+        description: *resourceVendorDescription
+
       partOfPackage:
         <<: *partOfPackage
         x-ums-reverse-relationship:
@@ -3270,6 +3305,10 @@ definitions:
         type: string
         minLength: 1
         description: *descriptionText
+
+      vendor:
+        <<: *vendor
+        description: *resourceVendorDescription
 
       version:
         <<: *version
@@ -3529,6 +3568,10 @@ definitions:
         <<: *aiHint
         examples: []
 
+      vendor:
+        <<: *vendor
+        description: *resourceVendorDescription
+
       partOfPackage:
         <<: *partOfPackage
         x-ums-reverse-relationship:
@@ -3749,6 +3792,10 @@ definitions:
         type: string
         minLength: 1
         description: *descriptionText
+
+      vendor:
+        <<: *vendor
+        description: *resourceVendorDescription
 
       partOfPackage:
         <<: *partOfPackage
@@ -5815,6 +5862,10 @@ definitions:
         minLength: 1
         description: *descriptionText
         examples: []
+
+      vendor:
+        <<: *vendor
+        description: *resourceVendorDescription
 
       partOfPackage:
         <<: *partOfPackage

--- a/src/generated/spec/v1/types/Document.ts
+++ b/src/generated/spec/v1/types/Document.ts
@@ -414,6 +414,17 @@ export interface ApiResource {
    */
   aiHint?: string;
   /**
+   * Vendor / organization that is the creator (or responsible party) of this resource.
+   *
+   * MUST be a valid reference to a [Vendor](#vendor) ORD ID.
+   *
+   * When omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)
+   * referenced via `partOfPackage`.
+   * If both are present, the resource-level `vendor` SHOULD match the Package `vendor`.
+   * If they differ, the explicitly assigned resource value takes precedence during aggregation.
+   */
+  vendor?: string;
+  /**
    * Defines which Package the resource is part of.
    *
    * MUST be a valid reference to a [Package](#package) ORD ID.
@@ -1378,6 +1389,17 @@ export interface EventResource {
    */
   aiHint?: string;
   /**
+   * Vendor / organization that is the creator (or responsible party) of this resource.
+   *
+   * MUST be a valid reference to a [Vendor](#vendor) ORD ID.
+   *
+   * When omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)
+   * referenced via `partOfPackage`.
+   * If both are present, the resource-level `vendor` SHOULD match the Package `vendor`.
+   * If they differ, the explicitly assigned resource value takes precedence during aggregation.
+   */
+  vendor?: string;
+  /**
    * Defines which Package the resource is part of.
    *
    * MUST be a valid reference to a [Package](#package) ORD ID.
@@ -1930,6 +1952,17 @@ export interface EntityType {
    */
   aiHint?: string;
   /**
+   * Vendor / organization that is the creator (or responsible party) of this resource.
+   *
+   * MUST be a valid reference to a [Vendor](#vendor) ORD ID.
+   *
+   * When omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)
+   * referenced via `partOfPackage`.
+   * If both are present, the resource-level `vendor` SHOULD match the Package `vendor`.
+   * If they differ, the explicitly assigned resource value takes precedence during aggregation.
+   */
+  vendor?: string;
+  /**
    * Defines which Package the resource is part of.
    *
    * MUST be a valid reference to a [Package](#package) ORD ID.
@@ -2279,6 +2312,17 @@ export interface Capability {
    */
   aiHint?: string;
   /**
+   * Vendor / organization that is the creator (or responsible party) of this resource.
+   *
+   * MUST be a valid reference to a [Vendor](#vendor) ORD ID.
+   *
+   * When omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)
+   * referenced via `partOfPackage`.
+   * If both are present, the resource-level `vendor` SHOULD match the Package `vendor`.
+   * If they differ, the explicitly assigned resource value takes precedence during aggregation.
+   */
+  vendor?: string;
+  /**
    * Defines which Package the resource is part of.
    *
    * MUST be a valid reference to a [Package](#package) ORD ID.
@@ -2595,6 +2639,17 @@ export interface DataProduct {
    * For guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources).
    */
   aiHint?: string;
+  /**
+   * Vendor / organization that is the creator (or responsible party) of this resource.
+   *
+   * MUST be a valid reference to a [Vendor](#vendor) ORD ID.
+   *
+   * When omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)
+   * referenced via `partOfPackage`.
+   * If both are present, the resource-level `vendor` SHOULD match the Package `vendor`.
+   * If they differ, the explicitly assigned resource value takes precedence during aggregation.
+   */
+  vendor?: string;
   /**
    * Defines which Package the resource is part of.
    *
@@ -3037,6 +3092,17 @@ export interface Agent {
    */
   aiHint?: string;
   /**
+   * Vendor / organization that is the creator (or responsible party) of this resource.
+   *
+   * MUST be a valid reference to a [Vendor](#vendor) ORD ID.
+   *
+   * When omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)
+   * referenced via `partOfPackage`.
+   * If both are present, the resource-level `vendor` SHOULD match the Package `vendor`.
+   * If they differ, the explicitly assigned resource value takes precedence during aggregation.
+   */
+  vendor?: string;
+  /**
    * Defines which Package the resource is part of.
    *
    * MUST be a valid reference to a [Package](#package) ORD ID.
@@ -3340,6 +3406,17 @@ export interface Overlay {
    */
   description?: string;
   /**
+   * Vendor / organization that is the creator (or responsible party) of this resource.
+   *
+   * MUST be a valid reference to a [Vendor](#vendor) ORD ID.
+   *
+   * When omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)
+   * referenced via `partOfPackage`.
+   * If both are present, the resource-level `vendor` SHOULD match the Package `vendor`.
+   * If they differ, the explicitly assigned resource value takes precedence during aggregation.
+   */
+  vendor?: string;
+  /**
    * The complete [SemVer](https://semver.org/) version string.
    *
    * It MUST follow the [Semantic Versioning 2.0.0](https://semver.org/) standard.
@@ -3558,6 +3635,17 @@ export interface IntegrationDependency {
    * Detailed documentation SHOULD be attached as (typed) links.
    */
   description?: string;
+  /**
+   * Vendor / organization that is the creator (or responsible party) of this resource.
+   *
+   * MUST be a valid reference to a [Vendor](#vendor) ORD ID.
+   *
+   * When omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)
+   * referenced via `partOfPackage`.
+   * If both are present, the resource-level `vendor` SHOULD match the Package `vendor`.
+   * If they differ, the explicitly assigned resource value takes precedence during aggregation.
+   */
+  vendor?: string;
   /**
    * Defines which Package the resource is part of.
    *
@@ -4095,6 +4183,13 @@ export interface Package {
    * MUST be set to `customer:vendor:Customer:` if the contents of the Package are created by the customer / user.
    *
    * MUST be set to a registered partner vendor, if the contents of the Package are created by a partner / third party.
+   *
+   * An ORD Aggregator SHOULD inherit `vendor` to every ORD resource contained in the Package
+   * when the resource does not declare `vendor` directly.
+   * If both are present, the resource-level `vendor` SHOULD match the Package `vendor`.
+   * If they differ, the explicitly assigned resource value takes precedence during aggregation.
+   *
+   * The Package assignment remains the shared source for inheritance to contained resources.
    */
   vendor: string;
   /**

--- a/static/spec-v1/interfaces/ums/AbstractMetadataType/ordresource.yaml
+++ b/static/spec-v1/interfaces/ums/AbstractMetadataType/ordresource.yaml
@@ -52,6 +52,12 @@ spec:
       mandatory: true
       constraints:
         minLength: 1
+    - name: 'vendor_ID'
+      type: 'guid'
+      description: "Vendor / organization that is the creator (or responsible party) of this resource.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nWhen omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)\nreferenced via `partOfPackage`.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation."
+      constraints:
+        maxLength: 256
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(vendor):([a-zA-Z0-9._\-]+):()$'
     - name: 'partOfPackage_ID'
       type: 'guid'
       description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
@@ -128,6 +134,12 @@ spec:
         - name: 'value'
           type: 'string'
   metadataRelations:
+    - propertyName: 'vendor'
+      relatedTypeName: 'Vendor'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      propertyBased: true
+      managedByProperty: 'vendor_ID'
+      description: "Vendor / organization that is the creator (or responsible party) of this resource.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nWhen omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)\nreferenced via `partOfPackage`.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation."
     - propertyName: 'partOfPackage'
       relatedTypeName: 'Package'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'

--- a/static/spec-v1/interfaces/ums/MetadataType/agent.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/agent.yaml
@@ -56,6 +56,12 @@ spec:
       description: "Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.\nIntentionally separate from human-facing `description` so both can evolve independently.\nSHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nFor guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources)."
       constraints:
         minLength: 1
+    - name: 'vendor_ID'
+      type: 'guid'
+      description: "Vendor / organization that is the creator (or responsible party) of this resource.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nWhen omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)\nreferenced via `partOfPackage`.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation."
+      constraints:
+        maxLength: 256
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(vendor):([a-zA-Z0-9._\-]+):()$'
     - name: 'partOfPackage_ID'
       type: 'guid'
       description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
@@ -213,6 +219,12 @@ spec:
         - name: 'value'
           type: 'string'
   metadataRelations:
+    - propertyName: 'vendor'
+      relatedTypeName: 'Vendor'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      propertyBased: true
+      managedByProperty: 'vendor_ID'
+      description: "Vendor / organization that is the creator (or responsible party) of this resource.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nWhen omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)\nreferenced via `partOfPackage`.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation."
     - propertyName: 'partOfPackage'
       relatedTypeName: 'Package'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'

--- a/static/spec-v1/interfaces/ums/MetadataType/apiresource.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/apiresource.yaml
@@ -58,6 +58,12 @@ spec:
       description: "Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.\nIntentionally separate from human-facing `description` so both can evolve independently.\nSHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nFor guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources)."
       constraints:
         minLength: 1
+    - name: 'vendor_ID'
+      type: 'guid'
+      description: "Vendor / organization that is the creator (or responsible party) of this resource.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nWhen omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)\nreferenced via `partOfPackage`.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation."
+      constraints:
+        maxLength: 256
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(vendor):([a-zA-Z0-9._\-]+):()$'
     - name: 'partOfPackage_ID'
       type: 'guid'
       description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
@@ -381,6 +387,12 @@ spec:
         - name: 'value'
           type: 'string'
   metadataRelations:
+    - propertyName: 'vendor'
+      relatedTypeName: 'Vendor'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      propertyBased: true
+      managedByProperty: 'vendor_ID'
+      description: "Vendor / organization that is the creator (or responsible party) of this resource.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nWhen omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)\nreferenced via `partOfPackage`.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation."
     - propertyName: 'partOfPackage'
       relatedTypeName: 'Package'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'

--- a/static/spec-v1/interfaces/ums/MetadataType/capability.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/capability.yaml
@@ -66,6 +66,12 @@ spec:
       description: "Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.\nIntentionally separate from human-facing `description` so both can evolve independently.\nSHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nFor guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources)."
       constraints:
         minLength: 1
+    - name: 'vendor_ID'
+      type: 'guid'
+      description: "Vendor / organization that is the creator (or responsible party) of this resource.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nWhen omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)\nreferenced via `partOfPackage`.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation."
+      constraints:
+        maxLength: 256
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(vendor):([a-zA-Z0-9._\-]+):()$'
     - name: 'partOfPackage_ID'
       type: 'guid'
       description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
@@ -212,6 +218,12 @@ spec:
         - name: 'value'
           type: 'string'
   metadataRelations:
+    - propertyName: 'vendor'
+      relatedTypeName: 'Vendor'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      propertyBased: true
+      managedByProperty: 'vendor_ID'
+      description: "Vendor / organization that is the creator (or responsible party) of this resource.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nWhen omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)\nreferenced via `partOfPackage`.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation."
     - propertyName: 'partOfPackage'
       relatedTypeName: 'Package'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'

--- a/static/spec-v1/interfaces/ums/MetadataType/dataproduct.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/dataproduct.yaml
@@ -58,6 +58,12 @@ spec:
       description: "Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.\nIntentionally separate from human-facing `description` so both can evolve independently.\nSHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nFor guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources)."
       constraints:
         minLength: 1
+    - name: 'vendor_ID'
+      type: 'guid'
+      description: "Vendor / organization that is the creator (or responsible party) of this resource.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nWhen omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)\nreferenced via `partOfPackage`.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation."
+      constraints:
+        maxLength: 256
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(vendor):([a-zA-Z0-9._\-]+):()$'
     - name: 'partOfPackage_ID'
       type: 'guid'
       description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
@@ -258,6 +264,12 @@ spec:
         - name: 'value'
           type: 'string'
   metadataRelations:
+    - propertyName: 'vendor'
+      relatedTypeName: 'Vendor'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      propertyBased: true
+      managedByProperty: 'vendor_ID'
+      description: "Vendor / organization that is the creator (or responsible party) of this resource.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nWhen omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)\nreferenced via `partOfPackage`.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation."
     - propertyName: 'partOfPackage'
       relatedTypeName: 'Package'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'

--- a/static/spec-v1/interfaces/ums/MetadataType/entitytype.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/entitytype.yaml
@@ -57,6 +57,12 @@ spec:
       description: "Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.\nIntentionally separate from human-facing `description` so both can evolve independently.\nSHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nFor guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources)."
       constraints:
         minLength: 1
+    - name: 'vendor_ID'
+      type: 'guid'
+      description: "Vendor / organization that is the creator (or responsible party) of this resource.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nWhen omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)\nreferenced via `partOfPackage`.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation."
+      constraints:
+        maxLength: 256
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(vendor):([a-zA-Z0-9._\-]+):()$'
     - name: 'partOfPackage_ID'
       type: 'guid'
       description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
@@ -243,6 +249,12 @@ spec:
         - name: 'value'
           type: 'string'
   metadataRelations:
+    - propertyName: 'vendor'
+      relatedTypeName: 'Vendor'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      propertyBased: true
+      managedByProperty: 'vendor_ID'
+      description: "Vendor / organization that is the creator (or responsible party) of this resource.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nWhen omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)\nreferenced via `partOfPackage`.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation."
     - propertyName: 'partOfPackage'
       relatedTypeName: 'Package'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'

--- a/static/spec-v1/interfaces/ums/MetadataType/eventresource.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/eventresource.yaml
@@ -58,6 +58,12 @@ spec:
       description: "Hint for AI consumers (LLMs, agent orchestrators) on how to use or interpret this resource.\nIntentionally separate from human-facing `description` so both can evolve independently.\nSHOULD be written in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nFor guidance and best practices, see [AI Agents and Protocols](../concepts/ai-agents-and-protocols#ai-hints-on-ord-resources)."
       constraints:
         minLength: 1
+    - name: 'vendor_ID'
+      type: 'guid'
+      description: "Vendor / organization that is the creator (or responsible party) of this resource.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nWhen omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)\nreferenced via `partOfPackage`.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation."
+      constraints:
+        maxLength: 256
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(vendor):([a-zA-Z0-9._\-]+):()$'
     - name: 'partOfPackage_ID'
       type: 'guid'
       description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
@@ -363,6 +369,12 @@ spec:
         - name: 'value'
           type: 'string'
   metadataRelations:
+    - propertyName: 'vendor'
+      relatedTypeName: 'Vendor'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      propertyBased: true
+      managedByProperty: 'vendor_ID'
+      description: "Vendor / organization that is the creator (or responsible party) of this resource.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nWhen omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)\nreferenced via `partOfPackage`.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation."
     - propertyName: 'partOfPackage'
       relatedTypeName: 'Package'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'

--- a/static/spec-v1/interfaces/ums/MetadataType/integrationdependency.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/integrationdependency.yaml
@@ -51,6 +51,12 @@ spec:
       description: "Full description, notated in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nThe description SHOULD not be excessive in length and is not meant to provide full documentation.\nDetailed documentation SHOULD be attached as (typed) links."
       constraints:
         minLength: 1
+    - name: 'vendor_ID'
+      type: 'guid'
+      description: "Vendor / organization that is the creator (or responsible party) of this resource.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nWhen omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)\nreferenced via `partOfPackage`.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation."
+      constraints:
+        maxLength: 256
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(vendor):([a-zA-Z0-9._\-]+):()$'
     - name: 'partOfPackage_ID'
       type: 'guid'
       description: "Defines which Package the resource is part of.\n\nMUST be a valid reference to a [Package](#package) ORD ID.\n\nEvery resource MUST be part of one package."
@@ -267,6 +273,12 @@ spec:
         - name: 'value'
           type: 'string'
   metadataRelations:
+    - propertyName: 'vendor'
+      relatedTypeName: 'Vendor'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      propertyBased: true
+      managedByProperty: 'vendor_ID'
+      description: "Vendor / organization that is the creator (or responsible party) of this resource.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nWhen omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)\nreferenced via `partOfPackage`.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation."
     - propertyName: 'partOfPackage'
       relatedTypeName: 'Package'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'

--- a/static/spec-v1/interfaces/ums/MetadataType/overlay.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/overlay.yaml
@@ -35,6 +35,12 @@ spec:
       description: "Full description, notated in [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nThe description SHOULD not be excessive in length and is not meant to provide full documentation.\nDetailed documentation SHOULD be attached as (typed) links."
       constraints:
         minLength: 1
+    - name: 'vendor_ID'
+      type: 'guid'
+      description: "Vendor / organization that is the creator (or responsible party) of this resource.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nWhen omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)\nreferenced via `partOfPackage`.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation."
+      constraints:
+        maxLength: 256
+        pattern: '^([a-z0-9]+(?:[.][a-z0-9]+)*):(vendor):([a-zA-Z0-9._\-]+):()$'
     - name: 'version'
       type: 'string'
       description: "The complete [SemVer](https://semver.org/) version string.\n\nIt MUST follow the [Semantic Versioning 2.0.0](https://semver.org/) standard.\nIt SHOULD be changed if the ORD information or referenced resource definitions changed.\nIt SHOULD express minor and patch changes that don't lead to incompatible changes.\n\nWhen the `version` major version changes, the [ORD ID](../index.md#ord-id) `<majorVersion>` fragment SHOULD be updated to be identical.\nIn case that a resource definition file also contains a version number (e.g. [OpenAPI `info`.`version`](https://spec.openapis.org/oas/v3.1.1.html#info-object)), it MUST be equal with the resource `version` to avoid inconsistencies.\n\nIf the resource has been extended by the user, the change MUST be indicated via `lastUpdate`.\nThe `version` MUST not be bumped for changes in extensions.\n\nThe general [Version and Lifecycle](../concepts/versioning-and-lifecycle.md) flow MUST be followed.\n\nNote: A change is only relevant for a version increment, if it affects the ORD resource or ORD taxonomy directly.\nFor example: If a resource within a `Package` changes, but the Package itself did not, the Package version does not need to be incremented."
@@ -117,6 +123,12 @@ spec:
         - name: 'value'
           type: 'string'
   metadataRelations:
+    - propertyName: 'vendor'
+      relatedTypeName: 'Vendor'
+      relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
+      propertyBased: true
+      managedByProperty: 'vendor_ID'
+      description: "Vendor / organization that is the creator (or responsible party) of this resource.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nWhen omitted, an ORD Aggregator SHOULD inherit `vendor` from the resource's [Package](#package)\nreferenced via `partOfPackage`.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation."
     - propertyName: 'relatedApiResources'
       relatedTypeName: 'RelatedApiResource'
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'

--- a/static/spec-v1/interfaces/ums/MetadataType/package.yaml
+++ b/static/spec-v1/interfaces/ums/MetadataType/package.yaml
@@ -99,7 +99,7 @@ spec:
         minLength: 1
     - name: 'vendor_ID'
       type: 'guid'
-      description: "Vendor / organization that is the creator (or responsible party) of the resources that are part of the `Package`.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nMUST be set to `customer:vendor:Customer:` if the contents of the Package are created by the customer / user.\n\nMUST be set to a registered partner vendor, if the contents of the Package are created by a partner / third party."
+      description: "Vendor / organization that is the creator (or responsible party) of the resources that are part of the `Package`.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nMUST be set to `customer:vendor:Customer:` if the contents of the Package are created by the customer / user.\n\nMUST be set to a registered partner vendor, if the contents of the Package are created by a partner / third party.\n\nAn ORD Aggregator SHOULD inherit `vendor` to every ORD resource contained in the Package\nwhen the resource does not declare `vendor` directly.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation.\n\nThe Package assignment remains the shared source for inheritance to contained resources."
       mandatory: true
       constraints:
         maxLength: 256
@@ -211,7 +211,7 @@ spec:
       relatedTypeNamespace: '/sap/core/ucl/metadata/ord/v1'
       propertyBased: true
       managedByProperty: 'vendor_ID'
-      description: "Vendor / organization that is the creator (or responsible party) of the resources that are part of the `Package`.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nMUST be set to `customer:vendor:Customer:` if the contents of the Package are created by the customer / user.\n\nMUST be set to a registered partner vendor, if the contents of the Package are created by a partner / third party."
+      description: "Vendor / organization that is the creator (or responsible party) of the resources that are part of the `Package`.\n\nMUST be a valid reference to a [Vendor](#vendor) ORD ID.\n\nMUST be set to `customer:vendor:Customer:` if the contents of the Package are created by the customer / user.\n\nMUST be set to a registered partner vendor, if the contents of the Package are created by a partner / third party.\n\nAn ORD Aggregator SHOULD inherit `vendor` to every ORD resource contained in the Package\nwhen the resource does not declare `vendor` directly.\nIf both are present, the resource-level `vendor` SHOULD match the Package `vendor`.\nIf they differ, the explicitly assigned resource value takes precedence during aggregation.\n\nThe Package assignment remains the shared source for inheritance to contained resources."
       mandatory: true
     - propertyName: 'partOfProducts'
       relatedTypeName: 'Product'


### PR DESCRIPTION
## Summary

Adds optional `vendor` and `partOfProducts` properties directly to every ORD resource type.
Package-level inheritance remains supported.
Direct resource-level `partOfProducts` assignments are complementary and are merged with inherited Package assignments.

## Motivation

This prepares the model for making Package assignment optional and potentially deprecating Packages in the future.
The related draft proposal to make `partOfPackage` optional is https://github.com/open-resource-discovery/specification/pull/162.
Moving the remaining shared metadata to resources lets consumers interpret and validate a resource without first resolving its Package, which may be published in another ORD document.
This is also needed by policies such as `sap:ai:v1`, which must determine the responsible vendor while validating an individual resource.

## Package-independent resources

A resource without a `partOfPackage` assignment cannot inherit Package metadata and must directly provide every property required from its Package context.
In the current model, `vendor` is the relevant mandatory Package property that was not previously available on every resource, while common identity and descriptive fields are already present directly on resources where applicable.
The specification now states that `vendor` MUST be provided directly for Package-capable resource types when no Package is assigned.
When draft PR 162 removes the unconditional `partOfPackage` requirement, its validation must enforce the resulting condition that either `partOfPackage` or direct `vendor` is present.

Product assignment remains recommended rather than mandatory.
When a resource has no Package, any product association must be expressed through its direct `partOfProducts` property.

## Open discussion

As an alternative, `vendor` and `partOfProducts` could be defined as ORD document-level defaults inherited by resources.
This could reduce repetition, but it would require clear override and merge semantics and must support documents containing resources from different vendors or products.
This PR does not introduce document-level defaults.
